### PR TITLE
Adding group_mod types

### DIFF
--- a/loxi_front_end/type_maps.py
+++ b/loxi_front_end/type_maps.py
@@ -569,6 +569,20 @@ flow_mod_types = {
     of_g.VERSION_1_3:common_flow_mod_types
     }
 
+common_group_mod_types = dict(
+    add = 0,
+    modify = 1,
+    delete = 2
+    )
+
+group_mod_types = {
+    # version 1.0
+    of_g.VERSION_1_0:dict(),
+    of_g.VERSION_1_1:common_group_mod_types,
+    of_g.VERSION_1_2:common_group_mod_types,
+    of_g.VERSION_1_3:common_group_mod_types
+    } 
+
 # These do not translate to objects (yet)
 error_types = {
     # version 1.0
@@ -754,6 +768,12 @@ flow_mod_list = [
     "of_flow_delete",
     "of_flow_delete_strict"
 ]
+
+group_mod_list = [
+    "of_group_add",
+    "of_group_delete",
+    "of_group_modify"
+    ]
 
 def sub_class_map(base_type, version):
     """

--- a/openflow_input/standard-1.1
+++ b/openflow_input/standard-1.1
@@ -954,12 +954,36 @@ struct ofp_bucket {
     list(of_action_t) actions;
 };
 
-struct ofp_group_mod {
+struct ofp_group_modify	{
     uint8_t version;
     uint8_t type;
     uint16_t length;
     uint32_t xid;
-    uint16_t command;
+    uint16_t _command;
+    uint8_t group_type;
+    uint8_t pad;
+    uint32_t group_id;
+    list(of_bucket_t) buckets;
+};
+
+struct ofp_group_add {
+    uint8_t version;
+    uint8_t type;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t _command;
+    uint8_t group_type;
+    uint8_t pad;
+    uint32_t group_id;
+    list(of_bucket_t) buckets;
+};
+
+struct ofp_group_delete {
+    uint8_t version;
+    uint8_t type;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t _command;
     uint8_t group_type;
     uint8_t pad;
     uint32_t group_id;

--- a/openflow_input/standard-1.2
+++ b/openflow_input/standard-1.2
@@ -876,12 +876,36 @@ struct ofp_bucket {
     list(of_action_t) actions;
 };
 
-struct ofp_group_mod {
+struct ofp_group_modify	{
     uint8_t version;
     uint8_t type;
     uint16_t length;
     uint32_t xid;
-    uint16_t command;
+    uint16_t _command;
+    uint8_t group_type;
+    uint8_t pad;
+    uint32_t group_id;
+    list(of_bucket_t) buckets;
+};
+
+struct ofp_group_add {
+    uint8_t version;
+    uint8_t type;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t _command;
+    uint8_t group_type;
+    uint8_t pad;
+    uint32_t group_id;
+    list(of_bucket_t) buckets;
+};
+
+struct ofp_group_delete {
+    uint8_t version;
+    uint8_t type;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t _command;
     uint8_t group_type;
     uint8_t pad;
     uint32_t group_id;

--- a/openflow_input/standard-1.3
+++ b/openflow_input/standard-1.3
@@ -1022,12 +1022,36 @@ struct ofp_bucket {
     list(of_action_t) actions;
 };
 
-struct ofp_group_mod {
+struct ofp_group_modify	{
     uint8_t version;
     uint8_t type;
     uint16_t length;
     uint32_t xid;
-    uint16_t command;
+    uint16_t _command;
+    uint8_t group_type;
+    uint8_t pad;
+    uint32_t group_id;
+    list(of_bucket_t) buckets;
+};
+
+struct ofp_group_add {
+    uint8_t version;
+    uint8_t type;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t _command;
+    uint8_t group_type;
+    uint8_t pad;
+    uint32_t group_id;
+    list(of_bucket_t) buckets;
+};
+
+struct ofp_group_delete {
+    uint8_t version;
+    uint8_t type;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t _command;
     uint8_t group_type;
     uint8_t pad;
     uint32_t group_id;

--- a/py_gen/codegen.py
+++ b/py_gen/codegen.py
@@ -52,6 +52,9 @@ def get_type_values(cls, version):
         if cls in type_maps.flow_mod_list:
             type_values['_command'] = util.constant_for_value(version, "ofp_flow_mod_command",
                                                               type_maps.flow_mod_types[version][cls[8:]])
+        if cls in type_maps.group_mod_list:
+            type_values['_command'] = util.constant_for_value(version, "ofp_group_mod_command",
+                                                              type_maps.group_mod_types[version][cls[9:]])
         if cls in type_maps.stats_request_list:
             type_values['stats_type'] = util.constant_for_value(version, "ofp_stats_types",
                                                                 type_maps.stats_types[version][cls[3:-14]])

--- a/py_gen/util.py
+++ b/py_gen/util.py
@@ -56,6 +56,8 @@ def primary_wire_type(cls, version):
         return type_maps.type_val[("of_stats_request", version)]
     elif cls in type_maps.flow_mod_list:
         return type_maps.type_val[("of_flow_mod", version)]
+    elif cls in type_maps.group_mod_list:
+        return type_maps.type_val[("of_group_mod", version)]
     elif (cls, version) in type_maps.type_val:
         return type_maps.type_val[(cls, version)]
     elif type_maps.message_is_extension(cls, version):


### PR DESCRIPTION
Added the add, modify, and delete group mod command types. A class is added to message.py for each one and populated with the proper OFPGC_*.
