### PR TITLE
Fix code generation on 32 bit systems.

### DIFF
--- a/loxi_front_end/identifiers.py
+++ b/loxi_front_end/identifiers.py
@@ -38,7 +38,7 @@ import of_g
 UNDEFINED_IDENT_VALUE = 0
 
 def add_identifier(name, ofp_name, ofp_group, value, version, all_idents, idents_by_group):
-    assert(isinstance(value, int))
+    assert(isinstance(value, (int,long)))
     if name in all_idents:
         all_idents[name]["values_by_version"][version] = value
         if ((all_idents[name]["ofp_name"] != ofp_name or


### PR DESCRIPTION
Python int limit is different on 32 and 64 bits systems.
e.g: The value 0xffffffff is considered long on 32 bits systems and
int on 64 bits systems.
