### PR TITLE
    Loxigen: added src/dst meta id matches

### DIFF
--- a/c_gen/c_match.py
+++ b/c_gen/c_match.py
@@ -274,6 +274,8 @@ enum of_oxm_index_e {
     OF_OXM_INDEX_IPV6_ND_TLL    = 33, /* Target link-layer for ND. */
     OF_OXM_INDEX_MPLS_LABEL     = 34, /* MPLS label. */
     OF_OXM_INDEX_MPLS_TC        = 35, /* MPLS TC. */
+    OF_OXM_INDEX_SRC_META_ID = 36,
+    OF_OXM_INDEX_DST_META_ID = 37,
 };
 
 #define OF_OXM_BIT(index) (((uint64_t) 1) << (index))

--- a/c_gen/templates/loci_show.h
+++ b/c_gen/templates/loci_show.h
@@ -332,6 +332,8 @@ int of_object_show(loci_writer_f writer, void *cookie, of_object_t *obj);
 #define LOCI_SHOW_u32_ipv4_netmask(writer, cookie, val) LOCI_SHOW_ipv4(writer, cookie, val)
 #define LOCI_SHOW_u8_l2_table_enable(writer, cookie, val) LOCI_SHOW_u8(writer, cookie, val)
 #define LOCI_SHOW_u16_l2_table_priority(writer, cookie, val) LOCI_SHOW_u16(writer, cookie, val)
+#define LOCI_SHOW_u8_src_meta_id(writer, cookie, val) LOCI_SHOW_u8(writer, cookie, val)
+#define LOCI_SHOW_u8_dst_meta_id(writer, cookie, val) LOCI_SHOW_u8(writer, cookie, val)
 
 
 

--- a/loxi_front_end/match.py
+++ b/loxi_front_end/match.py
@@ -394,6 +394,28 @@ of_match_members = dict(
         takes_mask_in_spec=False,
         order=501,
         ),
+
+    src_meta_id = dict(
+        name="src_meta_id",
+        m_type="uint8_t",
+        v1_wc_shift=23,
+        v2_wc_shift=23,
+        print_type="PRIx8",
+        conditions="",
+        takes_mask_in_spec=False,
+        order=600,
+        ),
+
+    dst_meta_id = dict(
+        name="dst_meta_id",
+        m_type="uint8_t",
+        v1_wc_shift=24,
+        v2_wc_shift=24,
+        print_type="PRIx8",
+        conditions="",
+        takes_mask_in_spec=False,
+        order=601,
+        ),
 )
 
 match_keys_sorted = of_match_members.keys()
@@ -411,7 +433,9 @@ of_v1_keys = [
     "tcp_dst",  # Means UDP too for 1.0 and 1.1
     "tcp_src",  # Means UDP too for 1.0 and 1.1
     "vlan_pcp",
-    "vlan_vid"
+    "vlan_vid",
+    "src_meta_id",
+    "dst_meta_id",
     ]
 
 of_v2_keys = [

--- a/openflow_input/oxm-1.2
+++ b/openflow_input/oxm-1.2
@@ -433,3 +433,25 @@ struct of_oxm_vlan_vid_masked {
     uint16_t value;
     uint16_t value_mask;
 };
+
+struct of_oxm_src_meta_id {
+    uint32_t type_len == 0x0003f001;
+    uint8_t value;
+};
+
+struct of_oxm_src_meta_id_masked {
+    uint32_t type_len == 0x0003f102;
+    uint8_t value;
+    uint8_t value_mask;
+};
+
+struct of_oxm_dst_meta_id {
+    uint32_t type_len == 0x0003f201;
+    uint8_t value;
+};
+
+struct of_oxm_dst_meta_id_masked {
+    uint32_t type_len == 0x0003f302;
+    uint8_t value;
+    uint8_t value_mask;
+};

--- a/openflow_input/standard-1.0
+++ b/openflow_input/standard-1.0
@@ -156,6 +156,8 @@ enum ofp_flow_wildcards {
     OFPFW_NW_DST_MASK = 0xfc000,
     OFPFW_DL_VLAN_PCP = 0x100000,
     OFPFW_NW_TOS = 0x200000,
+    OFPFW_SRC_META_ID = 0x400000,
+    OFPFW_DST_META_ID = 0x800000,
     OFPFW_ALL = 0x3fffff,
 };
 
@@ -562,7 +564,8 @@ struct of_match_v1 {
     uint16_t eth_type;
     uint8_t ip_dscp;
     uint8_t ip_proto;
-    pad(2);
+    uint8_t src_meta_id;
+    uint8_t dst_meta_id;
     uint32_t ipv4_src;
     uint32_t ipv4_dst;
     uint16_t tcp_src;

--- a/test_data/of10/flow_add.data
+++ b/test_data/of10/flow_add.data
@@ -42,6 +42,8 @@ flow_add {
     eth_type = 0x0,
     ip_dscp = 0x0,
     ip_proto = 0x0,
+    src_meta_id = 0x0,
+    dst_meta_id = 0x0,
     ipv4_src = 192.168.3.127,
     ipv4_dst = 255.255.255.255,
     tcp_src = 0x0,


### PR DESCRIPTION
Encode a 1 byte src and 1 byte dst 'meta' ID into
ofp_match's pad2 byte.

@dtalayco
