### PR TITLE
Removed $BIGCODE hack in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,3 @@ pylint:
 	pylint -E ${LOXI_PY_FILES}
 
 .PHONY: all clean debug check pylint c python
-
-ifdef BIGCODE
-# Internal build system compatibility
-MODULE := LoxiGen
-LOXI_OUTPUT_DIR = ${BIGCODE}/Modules
-modulemake:
-.PHONY: modulemake
-endif


### PR DESCRIPTION
old behavior: If $BIGCODE was defined, `make` would install into
    $BIGCODE/Modules

but... that was the wrong place and it was confusing.  Removed.

Reviewer: @rlane
