### PR TITLE
utest: add loxigen directory to front of sys.path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ debug:
 	@echo "INPUT_FILES=\"${INPUT_FILES}\""
 
 check:
-	PYTHONPATH=. ./utest/test_parser.py
-	PYTHONPATH=. ./utest/test_frontend.py
-	PYTHONPATH=. ./utest/test_test_data.py
+	./utest/test_parser.py
+	./utest/test_frontend.py
+	./utest/test_test_data.py
 
 check-py: python
 	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/generic_util.py

--- a/utest/test_frontend.py
+++ b/utest/test_frontend.py
@@ -26,7 +26,13 @@
 # EPL for the specific language governing permissions and limitations
 # under the EPL.
 
+import sys
+import os
 import unittest
+
+root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+sys.path.insert(0, root_dir)
+
 import loxi_front_end.parser as parser
 import loxi_front_end.frontend as frontend
 from loxi_ir import *

--- a/utest/test_parser.py
+++ b/utest/test_parser.py
@@ -26,7 +26,13 @@
 # EPL for the specific language governing permissions and limitations
 # under the EPL.
 
+import sys
+import os
 import unittest
+
+root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+sys.path.insert(0, root_dir)
+
 import pyparsing
 import loxi_front_end.parser as parser
 

--- a/utest/test_test_data.py
+++ b/utest/test_test_data.py
@@ -26,7 +26,13 @@
 # EPL for the specific language governing permissions and limitations
 # under the EPL.
 
+import sys
+import os
 import unittest
+
+root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+sys.path.insert(0, root_dir)
+
 import test_data
 
 class DataFileTests(unittest.TestCase):


### PR DESCRIPTION
Reviewer: trivial

Python prepends apt-get installed packages even before PYTHONPATH. This caused
the parser unit tests to fail on machines with an older version of pyparsing
installed even though it's included in the repo.
