### PR TITLE
Mask values in a match according to its masks

### DIFF
--- a/c_gen/c_test_gen.py
+++ b/c_gen/c_test_gen.py
@@ -261,6 +261,9 @@ of_match_populate(of_match_t *match, of_version_t version, int value)
         match->masks.ipv4_src = 0xffff0000;
         match->masks.ipv4_dst = 0xfffff800;
     }
+
+    /* Restrict values according to masks */
+    of_match_values_mask(match);
     return value;
 }
 


### PR DESCRIPTION
Reviewer:  @rlane

A step towards match canonicalization.  When generating a match
structure, clear the bits outside of those indicated by the
masks.  Changes to test code to make consistent.

For 1.0, need only worry about IPv4 addrs.  Otherwise, use a simple
loop to iterative over bytes in the match.
