### PR TITLE
openflow_input: add flags field to OF 1.3 flow stats entry

### DIFF
--- a/openflow_input/standard-1.3
+++ b/openflow_input/standard-1.3
@@ -1177,7 +1177,8 @@ struct of_flow_stats_entry {
     uint16_t priority;
     uint16_t idle_timeout;
     uint16_t hard_timeout;
-    pad(6);
+    uint16_t flags;
+    pad(4);
     uint64_t cookie;
     uint64_t packet_count;
     uint64_t byte_count;


### PR DESCRIPTION
Reviewer: trivial

This field was padding in OF 1.2.
