### PR TITLE
openflow_input: add discriminators to experimenter superclasses

### DIFF
--- a/openflow_input/standard-1.0
+++ b/openflow_input/standard-1.0
@@ -335,7 +335,7 @@ struct of_experimenter : of_header {
     uint8_t type == 4;
     uint16_t length;
     uint32_t xid;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
     of_octets_t data;
 };
@@ -525,7 +525,7 @@ struct of_action_set_nw_tos : of_action {
 struct of_action_experimenter : of_action {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -919,7 +919,7 @@ struct of_experimenter_stats_request : of_stats_request {
     uint32_t xid;
     uint16_t stats_type == 0xffff;
     uint16_t flags;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -930,7 +930,7 @@ struct of_experimenter_stats_reply : of_stats_reply {
     uint32_t xid;
     uint16_t stats_type == 0xffff;
     uint16_t flags;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 

--- a/openflow_input/standard-1.1
+++ b/openflow_input/standard-1.1
@@ -443,7 +443,7 @@ struct of_experimenter : of_header {
     uint8_t type == 4;
     uint16_t length;
     uint32_t xid;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
     of_octets_t data;
 };
@@ -742,7 +742,7 @@ struct of_action_dec_nw_ttl : of_action {
 struct of_action_experimenter : of_action {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -837,7 +837,7 @@ struct of_instruction_clear_actions : of_instruction {
 struct of_instruction_experimenter : of_instruction {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -1327,7 +1327,7 @@ struct of_experimenter_stats_request : of_stats_request {
     uint16_t stats_type == 0xffff;
     uint16_t flags;
     pad(4);
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     pad(4);
     of_octets_t data;
 };
@@ -1340,7 +1340,7 @@ struct of_experimenter_stats_reply : of_stats_reply {
     uint16_t stats_type == 0xffff;
     uint16_t flags;
     pad(4);
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     pad(4);
     of_octets_t data;
 };

--- a/openflow_input/standard-1.2
+++ b/openflow_input/standard-1.2
@@ -483,7 +483,7 @@ struct of_experimenter : of_header {
     uint8_t type == 4;
     uint16_t length;
     uint32_t xid;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
     of_octets_t data;
 };
@@ -699,7 +699,7 @@ struct of_action_set_field : of_action {
 struct of_action_experimenter : of_action {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -753,7 +753,7 @@ struct of_instruction_clear_actions : of_instruction {
 struct of_instruction_experimenter : of_instruction {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -1317,7 +1317,7 @@ struct of_experimenter_stats_request : of_stats_request {
     uint16_t stats_type == 0xffff;
     uint16_t flags;
     pad(4);
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
     of_octets_t data;
 };
@@ -1330,7 +1330,7 @@ struct of_experimenter_stats_reply : of_stats_reply {
     uint16_t stats_type == 0xffff;
     uint16_t flags;
     pad(4);
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
     of_octets_t data;
 };
@@ -1363,7 +1363,7 @@ struct of_queue_prop_experimenter : of_queue_prop {
     uint16_t type == 65535;
     uint16_t len;
     pad(4);
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     pad(4);
     of_octets_t data;
 };

--- a/openflow_input/standard-1.3
+++ b/openflow_input/standard-1.3
@@ -608,7 +608,7 @@ struct of_experimenter : of_header {
     uint8_t type == 4;
     uint16_t length;
     uint32_t xid;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
     of_octets_t data;
 };
@@ -833,7 +833,7 @@ struct of_action_set_field : of_action {
 struct of_action_experimenter : of_action {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -905,7 +905,7 @@ struct of_instruction_meter : of_instruction {
 struct of_instruction_experimenter : of_instruction {
     uint16_t type == 65535;
     uint16_t len;
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     of_octets_t data;
 };
 
@@ -1770,7 +1770,7 @@ struct of_meter_config {
 };
 
 struct of_experimenter_multipart_header {
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     uint32_t subtype;
 };
 
@@ -1802,7 +1802,7 @@ struct of_queue_prop_experimenter : of_queue_prop {
     uint16_t type == 65535;
     uint16_t len;
     pad(4);
-    uint32_t experimenter;
+    uint32_t experimenter == ?;
     pad(4);
     of_octets_t data;
 };

--- a/py_gen/codegen.py
+++ b/py_gen/codegen.py
@@ -54,13 +54,10 @@ def generate_pyname(cls):
 # Create intermediate representation, extended from the LOXI IR
 # HACK the oftype member attribute is replaced with an OFType instance
 def build_ofclasses(version):
-    blacklist = ["of_experimenter", "of_action_experimenter"]
     ofclasses = []
     for ofclass in of_g.ir[version].classes:
         cls = ofclass.name
-        if type_maps.class_is_virtual(cls):
-            continue
-        if cls in blacklist:
+        if ofclass.virtual:
             continue
 
         members = []

--- a/py_gen/templates/message.py
+++ b/py_gen/templates/message.py
@@ -226,11 +226,6 @@ stats_reply_parsers = {
     const.OFPST_TABLE : table_stats_reply.unpack,
     const.OFPST_PORT : port_stats_reply.unpack,
     const.OFPST_QUEUE : queue_stats_reply.unpack,
-:: if version < of_g.VERSION_1_1:
-    const.OFPST_VENDOR : experimenter_stats_reply.unpack,
-:: else:
-    const.OFPST_EXPERIMENTER : experimenter_stats_reply.unpack,
-:: #endif
 :: if version >= of_g.VERSION_1_1:
     const.OFPST_GROUP : group_stats_reply.unpack,
     const.OFPST_GROUP_DESC : group_desc_stats_reply.unpack,
@@ -247,11 +242,6 @@ stats_request_parsers = {
     const.OFPST_TABLE : table_stats_request.unpack,
     const.OFPST_PORT : port_stats_request.unpack,
     const.OFPST_QUEUE : queue_stats_request.unpack,
-:: if version < of_g.VERSION_1_1:
-    const.OFPST_VENDOR : experimenter_stats_request.unpack,
-:: else:
-    const.OFPST_EXPERIMENTER : experimenter_stats_request.unpack,
-:: #endif
 :: if version >= of_g.VERSION_1_1:
     const.OFPST_GROUP : group_stats_request.unpack,
     const.OFPST_GROUP_DESC : group_desc_stats_request.unpack,


### PR DESCRIPTION
Reviewer: @andi-bigswitch

Also fix the Python backend to replace its logic for ignoring virtual classes 
to just use the IR.
