### PR TITLE
More java fields (ICMPv6,MPLS), warnings removal from generated code, getMatch() method, unit tests update

### DIFF
--- a/java_gen/java_model.py
+++ b/java_gen/java_model.py
@@ -112,7 +112,22 @@ class JavaModel(object):
                 "OFOxmIpv6Dst":             OxmMapEntry("IPv6", "IPV6_DST", False),
                 "OFOxmIpv6DstMasked":       OxmMapEntry("IPv6", "IPV6_DST", True),
                 "OFOxmIpv6Flabel":          OxmMapEntry("IPv6FlowLabel", "IPV6_FLABEL", False),
-                "OFOxmIpv6FlabelMasked":    OxmMapEntry("IPv6FlowLabel", "IPV6_FLABEL", True) }
+                "OFOxmIpv6FlabelMasked":    OxmMapEntry("IPv6FlowLabel", "IPV6_FLABEL", True),
+                "OFOxmIcmpv6Type":          OxmMapEntry("U8", "ICMPV6_TYPE", False),
+                "OFOxmIcmpv6TypeMasked":    OxmMapEntry("U8", "ICMPV6_TYPE", True),
+                "OFOxmIcmpv6Code":          OxmMapEntry("U8", "ICMPV6_CODE", False),
+                "OFOxmIcmpv6CodeMasked":    OxmMapEntry("U8", "ICMPV6_CODE", True),
+                "OFOxmIpv6NdTarget":        OxmMapEntry("IPv6", "IPV6_ND_TARGET", False),
+                "OFOxmIpv6NdTargetMasked":  OxmMapEntry("IPv6", "IPV6_ND_TARGET", True),
+                "OFOxmIpv6NdSll":           OxmMapEntry("MacAddress", "IPV6_ND_SLL", False),
+                "OFOxmIpv6NdSllMasked":     OxmMapEntry("MacAddress", "IPV6_ND_SLL", True),
+                "OFOxmIpv6NdTll":           OxmMapEntry("MacAddress", "IPV6_ND_TLL", False),
+                "OFOxmIpv6NdTllMasked":     OxmMapEntry("MacAddress", "IPV6_ND_TLL", True),
+                "OFOxmMplsLabel":           OxmMapEntry("U32", "MPLS_LABEL", False),
+                "OFOxmMplsLabelMasked":     OxmMapEntry("U32", "MPLS_LABEL", True),
+                "OFOxmMplsTc":              OxmMapEntry("U8", "MPLS_TC", False),
+                "OFOxmMplsTcMasked":        OxmMapEntry("U8", "MPLS_TC", True)
+                }
 
     @property
     @memoize

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -15,6 +15,8 @@ import org.projectfloodlight.openflow.types.OFMetadata;
 import org.projectfloodlight.openflow.types.OFPort;
 import org.projectfloodlight.openflow.types.OFValueType;
 import org.projectfloodlight.openflow.types.TransportPort;
+import org.projectfloodlight.openflow.types.U32;
+import org.projectfloodlight.openflow.types.U8;
 import org.projectfloodlight.openflow.types.VlanPcp;
 import org.projectfloodlight.openflow.types.VlanVid;
 
@@ -139,6 +141,34 @@ public class MatchField<F extends OFValueType<F>> {
     public final static MatchField<IPv6FlowLabel> IPV6_FLABEL =
             new MatchField<IPv6FlowLabel>("ipv6_flabel", MatchFields.IPV6_FLABEL,
                     new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ETH_TYPE_IPv6));
+
+    public final static MatchField<U8> ICMPV6_TYPE =
+            new MatchField<U8>("icmpv6_type", MatchFields.ICMPV6_TYPE,
+                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.IP_PROTO_IPv6_ICMP));
+
+    public final static MatchField<U8> ICMPV6_CODE =
+            new MatchField<U8>("icmpv6_code", MatchFields.ICMPV6_CODE,
+                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.IP_PROTO_IPv6_ICMP));
+
+    public final static MatchField<IPv6> IPV6_ND_TARGET =
+            new MatchField<IPv6>("ipv6_nd_target", MatchFields.IPV6_ND_TARGET,
+                    new Prerequisite<U8>(MatchField.ICMPV6_TYPE, U8.of((short)135), U8.of((short)136)));
+
+    public final static MatchField<MacAddress> IPV6_ND_SLL =
+            new MatchField<MacAddress>("ipv6_nd_sll", MatchFields.IPV6_ND_SLL,
+                    new Prerequisite<U8>(MatchField.ICMPV6_TYPE, U8.of((short)135)));
+
+    public final static MatchField<MacAddress> IPV6_ND_TLL =
+            new MatchField<MacAddress>("ipv6_nd_tll", MatchFields.IPV6_ND_TLL,
+                    new Prerequisite<U8>(MatchField.ICMPV6_TYPE, U8.of((short)136)));
+
+    public final static MatchField<U32> MPLS_LABEL =
+            new MatchField<U32>("mpls_label", MatchFields.MPLS_LABEL,
+                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ETH_TYPE_MPLS_UNICAST, EthType.ETH_TYPE_MPLS_MULTICAST));
+
+    public final static MatchField<U8> MPLS_TC =
+            new MatchField<U8>("mpls_tc", MatchFields.MPLS_TC,
+                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ETH_TYPE_MPLS_UNICAST, EthType.ETH_TYPE_MPLS_MULTICAST));
 
     public String getName() {
         return name;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchFields.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchFields.java
@@ -31,4 +31,11 @@ public enum MatchFields {
     IPV6_SRC,
     IPV6_DST,
     IPV6_FLABEL,
+    ICMPV6_TYPE,
+    ICMPV6_CODE,
+    IPV6_ND_TARGET,
+    IPV6_ND_SLL,
+    IPV6_ND_TLL,
+    MPLS_LABEL,
+    MPLS_TC
 }

--- a/java_gen/templates/of_class.java
+++ b/java_gen/templates/of_class.java
@@ -145,7 +145,12 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
     static class Reader implements OFMessageReader<${msg.interface.name}> {
         @Override
         public ${msg.interface.name} readFrom(ChannelBuffer bb) throws OFParseError {
+//:: for prop in msg.members:
+//:: if not prop.is_virtual and (prop.is_length_value or prop.is_field_length_value):
             int start = bb.readerIndex();
+//::     break
+//:: #endif
+//:: #endfor
 //:: fields_with_length_member = {}
 //:: for prop in msg.members:
 //:: if prop.is_virtual:
@@ -203,7 +208,9 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
     static class Writer implements OFMessageWriter<${impl_class}> {
         @Override
         public void write(ChannelBuffer bb, ${impl_class} message) {
+//:: if not msg.is_fixed_length:
             int startIndex = bb.writerIndex();
+//:: #endif
 //:: fields_with_length_member = {}
 //:: for prop in msg.members:
 //:: if prop.c_name in fields_with_length_member:
@@ -278,7 +285,9 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
             return false;
         if (getClass() != obj.getClass())
             return false;
+        //:: if len(msg.data_members) > 0:
         ${msg.name} other = (${msg.name}) obj;
+        //:: #endif
 
         //:: for prop in msg.data_members:
         //:: if prop.java_type.is_primitive:
@@ -300,7 +309,9 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
 
     @Override
     public int hashCode() {
+        //:: if len(msg.data_members) > 0:
         final int prime = 31;
+        //:: #endif
         int result = 1;
 
         //:: for prop in msg.data_members:

--- a/java_gen/templates/of_factory_class.java
+++ b/java_gen/templates/of_factory_class.java
@@ -27,11 +27,14 @@
 //::
 //:: import itertools
 //:: import of_g
+//:: import re
 //:: include('_copyright.java')
 
 //:: include('_autogen.java')
 
 package ${factory.package};
+
+import org.projectfloodlight.openflow.protocol.OFOxmList;
 
 //:: include("_imports.java")
 
@@ -45,10 +48,13 @@ public class ${factory.name} implements ${factory.interface.name} {
     }
     //:: #endfor
 
+//:: general_get_match_func_written = False
 //:: for i in factory.interface.members:
     //:: if i.is_virtual:
     //::    continue
     //:: #endif
+    //:: is_match_object = re.match('OFMatch.*', i.name) # i.has_version(factory.version) and model.generate_class(i.versioned_class(factory.version)) and i.versioned_class(factory.version).interface.parent_interface == 'Match'
+    //:: unsupported_match_object = is_match_object and not i.has_version(factory.version)
 
     //:: if len(i.writeable_members) > 0:
     public ${i.name}.Builder ${factory.interface.method_name(i, builder=True)}() {
@@ -58,6 +64,12 @@ public class ${factory.name} implements ${factory.interface.name} {
         throw new UnsupportedOperationException("${i.name} not supported in version ${factory.version}");
         //:: #endif
     }
+    //:: #endif
+    //:: if not general_get_match_func_written and is_match_object and not unsupported_match_object:
+    public Match.Builder buildMatch() {
+        return new ${i.versioned_class(factory.version).name}.Builder();
+    }
+    //::     general_get_match_func_written = True
     //:: #endif
     //:: if len(i.writeable_members) <= 2:
     public ${i.name} ${factory.interface.method_name(i, builder=False)}(${", ".join("%s %s" % (p.java_type.public_type, p.name) for p in i.writeable_members)}) {

--- a/java_gen/templates/of_factory_interface.java
+++ b/java_gen/templates/of_factory_interface.java
@@ -27,6 +27,7 @@
 //::
 //:: import itertools
 //:: import of_g
+//:: import re
 //:: include('_copyright.java')
 
 //:: include('_autogen.java')
@@ -52,6 +53,9 @@ public interface ${factory.name} {
     ${i.name} ${factory.method_name(i, builder=False )}(${", ".join("%s %s" % (p.java_type.public_type, p.name) for p in i.writeable_members)});
     //:: #endif
 //:: #endfor
+//:: if factory.name == 'OFFactory':
+    Match.Builder buildMatch();
+//:: #endif
 
     OFMessageReader<${factory.base_class}> getReader();
 

--- a/java_gen/templates/of_virtual_class.java
+++ b/java_gen/templates/of_virtual_class.java
@@ -51,7 +51,7 @@ abstract class ${msg.name} {
 
     static class Reader implements OFMessageReader<${msg.interface.inherited_declaration()}> {
         @Override
-        public ${msg.interface.name} readFrom(ChannelBuffer bb) throws OFParseError {
+        public ${msg.interface.inherited_declaration()} readFrom(ChannelBuffer bb) throws OFParseError {
 //:: if msg.is_fixed_length:
             if(bb.readableBytes() < LENGTH)
 //:: else:

--- a/test_data/of13/flow_add.data
+++ b/test_data/of13/flow_add.data
@@ -85,7 +85,7 @@ builder.setXid(0x12345678)
     .setOutGroup(8)
     .setFlags(0)
     .setMatch(
-        factory.buildMatchV3()
+        factory.buildMatch()
             .setMasked(MatchField.IN_PORT, OFPort.of(4), OFPort.of(5))
             .setExact(MatchField.ETH_TYPE, EthType.ETH_TYPE_IPv6)
             .setExact(MatchField.IP_PROTO, IpProtocol.IP_PROTO_TCP)

--- a/test_data/of13/flow_delete.data
+++ b/test_data/of13/flow_delete.data
@@ -85,7 +85,7 @@ builder.setXid(0x12345678)
     .setOutGroup(8)
     .setFlags(0)
     .setMatch(
-        factory.buildMatchV3()
+        factory.buildMatch()
             .setMasked(MatchField.IN_PORT, OFPort.of(4), OFPort.of(5))
             .setExact(MatchField.ETH_TYPE, EthType.ETH_TYPE_IPv6)
             .setExact(MatchField.IP_PROTO, IpProtocol.IP_PROTO_TCP)

--- a/test_data/of13/flow_delete_strict.data
+++ b/test_data/of13/flow_delete_strict.data
@@ -85,7 +85,7 @@ builder.setXid(0x12345678)
     .setOutGroup(8)
     .setFlags(0)
     .setMatch(
-        factory.buildMatchV3()
+        factory.buildMatch()
             .setMasked(MatchField.IN_PORT, OFPort.of(4), OFPort.of(5))
             .setExact(MatchField.ETH_TYPE, EthType.ETH_TYPE_IPv6)
             .setExact(MatchField.IP_PROTO, IpProtocol.IP_PROTO_TCP)

--- a/test_data/of13/flow_modify.data
+++ b/test_data/of13/flow_modify.data
@@ -85,7 +85,7 @@ builder.setXid(0x12345678)
     .setOutGroup(8)
     .setFlags(0)
     .setMatch(
-        factory.buildMatchV3()
+        factory.buildMatch()
             .setMasked(MatchField.IN_PORT, OFPort.of(4), OFPort.of(5))
             .setExact(MatchField.ETH_TYPE, EthType.ETH_TYPE_IPv6)
             .setExact(MatchField.IP_PROTO, IpProtocol.IP_PROTO_TCP)

--- a/test_data/of13/flow_modify_strict.data
+++ b/test_data/of13/flow_modify_strict.data
@@ -85,7 +85,7 @@ builder.setXid(0x12345678)
     .setOutGroup(8)
     .setFlags(0)
     .setMatch(
-        factory.buildMatchV3()
+        factory.buildMatch()
             .setMasked(MatchField.IN_PORT, OFPort.of(4), OFPort.of(5))
             .setExact(MatchField.ETH_TYPE, EthType.ETH_TYPE_IPv6)
             .setExact(MatchField.IP_PROTO, IpProtocol.IP_PROTO_TCP)


### PR DESCRIPTION
1. Added more match fields for ICMPv6 and MPLS
2. Fixes to avoid unnecessary warnings in generated code
3. Added the general method Match getMatch() to factories and made unit tests use it

Reviewer: @andi-bigswitch
