### PR TITLE
fix loci OXM ordering to match the spec

### DIFF
--- a/c_gen/c_match.py
+++ b/c_gen/c_match.py
@@ -602,8 +602,8 @@ populate_oxm_list(of_match_t *src, of_list_oxm_t *oxm_list)
 
     /* For each active member, add an OXM entry to the list */
 """)
-    # @fixme Would like to generate the list in some reasonable order
-    for key, entry in match.of_match_members.items():
+    for key in match.match_keys_sorted:
+        entry = match.of_match_members[key]
         out.write("""\
     if (OF_MATCH_MASK_%(ku)s_ACTIVE_TEST(src)) {
         if (!OF_MATCH_MASK_%(ku)s_EXACT_TEST(src)) {

--- a/loxi_front_end/match.py
+++ b/loxi_front_end/match.py
@@ -145,24 +145,7 @@ of_match_members = dict(
         takes_mask_in_spec=False,
         order=211,
         ),
-    ipv4_src = dict(
-        name="ipv4_src",
-        m_type="of_ipv4_t",
-        v1_wc_shift=8,
-        print_type="PRIx32",
-        conditions="is_ipv4(match)",
-        takes_mask_in_spec=True,
-        order=300,
-        ),
-    ipv4_dst = dict(
-        name="ipv4_dst",
-        m_type="of_ipv4_t",
-        v1_wc_shift=14,
-        print_type="PRIx32",
-        conditions="is_ipv4(match)",
-        takes_mask_in_spec=True,
-        order=301,
-        ),
+
     ip_dscp = dict(
         name="ip_dscp",
         m_type="uint8_t",
@@ -190,6 +173,24 @@ of_match_members = dict(
         conditions="is_ip(match)",
         takes_mask_in_spec=False,
         order=320,
+        ),
+    ipv4_src = dict(
+        name="ipv4_src",
+        m_type="of_ipv4_t",
+        v1_wc_shift=8,
+        print_type="PRIx32",
+        conditions="is_ipv4(match)",
+        takes_mask_in_spec=True,
+        order=330,
+        ),
+    ipv4_dst = dict(
+        name="ipv4_dst",
+        m_type="of_ipv4_t",
+        v1_wc_shift=14,
+        print_type="PRIx32",
+        conditions="is_ipv4(match)",
+        takes_mask_in_spec=True,
+        order=331,
         ),
 
     tcp_dst = dict(
@@ -270,7 +271,7 @@ of_match_members = dict(
         print_type="PRIx16",
         conditions="is_arp(match)",
         takes_mask_in_spec=False,
-        order=250,
+        order=450,
         ),
 
     arp_spa = dict(
@@ -279,7 +280,7 @@ of_match_members = dict(
         print_type="PRIx32",
         conditions="is_arp(match)",
         takes_mask_in_spec=True,
-        order=251,
+        order=451,
         ),
     arp_tpa = dict(
         name="arp_tpa",
@@ -287,7 +288,7 @@ of_match_members = dict(
         print_type="PRIx32",
         conditions="is_arp(match)",
         takes_mask_in_spec=True,
-        order=252,
+        order=452,
         ),
 
     arp_sha = dict(
@@ -296,7 +297,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="is_arp(match)",
         takes_mask_in_spec=False,
-        order=253,
+        order=453,
         ),
     arp_tha = dict(
         name="arp_tha",
@@ -304,7 +305,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="is_arp(match)",
         takes_mask_in_spec=False,
-        order=254,
+        order=454,
         ),
 
     ipv6_src = dict(
@@ -313,7 +314,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="is_ipv6(match)",
         takes_mask_in_spec=True,
-        order=350,
+        order=500,
         ),
     ipv6_dst = dict(
         name="ipv6_dst",
@@ -321,7 +322,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="is_ipv6(match)",
         takes_mask_in_spec=True,
-        order=351,
+        order=501,
         ),
 
     ipv6_flabel = dict(
@@ -330,7 +331,7 @@ of_match_members = dict(
         print_type="PRIx32",
         conditions="is_ipv6(match)",
         takes_mask_in_spec=False, # Comment in openflow.h says True
-        order=360,
+        order=502,
         ),
 
     icmpv6_type = dict(
@@ -339,7 +340,7 @@ of_match_members = dict(
         print_type="PRIx8",
         conditions="is_icmp_v6(match)",
         takes_mask_in_spec=False,
-        order=440,
+        order=510,
         ),
     icmpv6_code = dict(
         name="icmpv6_code",
@@ -347,7 +348,7 @@ of_match_members = dict(
         print_type="PRIx8",
         conditions="is_icmp_v6(match)",
         takes_mask_in_spec=False,
-        order=441,
+        order=511,
         ),
 
     ipv6_nd_target = dict(
@@ -356,7 +357,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="", # fixme
         takes_mask_in_spec=False,
-        order=442,
+        order=512,
         ),
 
     ipv6_nd_sll = dict(
@@ -365,7 +366,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="", # fixme
         takes_mask_in_spec=False,
-        order=443,
+        order=520,
         ),
     ipv6_nd_tll = dict(
         name="ipv6_nd_tll",
@@ -373,7 +374,7 @@ of_match_members = dict(
         print_type="\"p\"",
         conditions="", # fixme
         takes_mask_in_spec=False,
-        order=444,
+        order=521,
         ),
 
     mpls_label = dict(
@@ -383,7 +384,7 @@ of_match_members = dict(
         print_type="PRIx32",
         conditions="",
         takes_mask_in_spec=False,
-        order=500,
+        order=600,
         ),
     mpls_tc = dict(
         name="mpls_tc",
@@ -392,7 +393,7 @@ of_match_members = dict(
         print_type="PRIx8",
         conditions="",
         takes_mask_in_spec=False,
-        order=501,
+        order=601,
         ),
 
     bsn_in_ports_128 = dict(


### PR DESCRIPTION
Reviewer: @andi-bigswitch

The C backend will now output OXMs in the same order as the Java backend.
