### PR TITLE
openflow_input: fix naming of group type in group desc stats entry

### DIFF
--- a/openflow_input/standard-1.1
+++ b/openflow_input/standard-1.1
@@ -1202,7 +1202,7 @@ struct of_group_stats_entry {
 
 struct of_group_desc_stats_entry {
     uint16_t length;
-    uint8_t type;
+    uint8_t group_type;
     pad(1);
     uint32_t group_id;
     list(of_bucket_t) buckets;

--- a/openflow_input/standard-1.2
+++ b/openflow_input/standard-1.2
@@ -1171,7 +1171,7 @@ struct of_group_stats_entry {
 
 struct of_group_desc_stats_entry {
     uint16_t length;
-    uint8_t type;
+    uint8_t group_type;
     pad(1);
     uint32_t group_id;
     list(of_bucket_t) buckets;

--- a/openflow_input/standard-1.3
+++ b/openflow_input/standard-1.3
@@ -1382,7 +1382,7 @@ struct of_group_stats_entry {
 
 struct of_group_desc_stats_entry {
     uint16_t length;
-    uint8_t type;
+    uint8_t group_type;
     pad(1);
     uint32_t group_id;
     list(of_bucket_t) buckets;

--- a/test_data/of13/group_desc_stats_reply.data
+++ b/test_data/of13/group_desc_stats_reply.data
@@ -49,7 +49,7 @@ ofp.message.group_desc_stats_reply(
     flags=0,
     entries=[
         ofp.group_desc_stats_entry(
-            type=ofp.OFPGT_FF,
+            group_type=ofp.OFPGT_FF,
             group_id=1,
             buckets=[
                 ofp.bucket(
@@ -66,4 +66,4 @@ ofp.message.group_desc_stats_reply(
                     actions=[
                         ofp.action.output(port=5, max_len=0),
                         ofp.action.output(port=6, max_len=0)])]),
-        ofp.group_desc_stats_entry(type=ofp.OFPGT_FF, group_id=2, buckets=[])])
+        ofp.group_desc_stats_entry(group_type=ofp.OFPGT_FF, group_id=2, buckets=[])])


### PR DESCRIPTION
Reviewer: trivial

The C backend blacklists the name "type" so accessors aren't generated.
"group_type" works and is consistent with the other classes.
