### PR TITLE
Remove duplicate function getOpCode().

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ArpOpcode.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ArpOpcode.java
@@ -159,10 +159,6 @@ public class ArpOpcode implements OFValueType<ArpOpcode> {
         return ArpOpcode.of(this.opcode & mask.opcode);
     }
 
-    public int getOpCode() {
-        return opcode;
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;


### PR DESCRIPTION
Reviewer: @andi-bigswitch @rlane
- getOpCode() does NOT match the camel casing of the class name ArpOpcode
- getOpcode() match the camel casing of the class name ArpOpcode
- These 2 functions do the same thing
- getOpCode() (the one to be removed) does not seem to be used in Floodlight
- We cannot be sure that it is not used anywhere else though
