### PR TITLE
loci: expose group-mod subtypes

### DIFF
--- a/c_gen/build_of_g.py
+++ b/c_gen/build_of_g.py
@@ -317,8 +317,6 @@ def build_ordered_classes():
         version_name = of_g.of_version_wire2name[wire_version]
 
         for ofclass in protocol.classes:
-            if ofclass.name in ("of_group_add", "of_group_modify", "of_group_delete"):
-                continue
             of_g.ordered_classes[wire_version].append(ofclass.name)
             legacy_members = []
             pad_count = 0
@@ -416,9 +414,6 @@ def populate_type_maps():
             if not [x for x in ofclass.members if isinstance(x, OFDataMember) and x.name == 'xid']:
                 continue
             if type_maps.class_is_virtual(cls):
-                continue
-            # HACK hide of_group subclasses from legacy c backend
-            if ofclass.name in ("of_group_add", "of_group_modify", "of_group_delete"):
                 continue
             subcls = cls[3:]
             val = find_type_value(ofclass, 'type')

--- a/c_gen/c_type_maps.py
+++ b/c_gen/c_type_maps.py
@@ -75,6 +75,10 @@ def gen_object_id_to_type(out):
                 out.write("    %d%s /* %s */\n" %
                           (type_maps.type_val[("of_flow_mod", version)],
                            comma, cls))
+            elif cls in type_maps.group_mod_list and version > 1:
+                out.write("    %d%s /* %s */\n" %
+                          (type_maps.type_val[("of_group_mod", version)],
+                           comma, cls))
             elif (cls, version) in type_maps.type_val and \
                     type_maps.type_val[(cls, version)] != type_maps.invalid_type:
                 out.write("    %d%s /* %s */\n" %
@@ -260,6 +264,9 @@ def gen_type_maps(out):
                           max_type_value)
     gen_type_to_object_id(out, "hello_elem_type_to_id", "OF_HELLO_ELEM",
                           "OF_HELLO_ELEM_%s", type_maps.hello_elem_types,
+                          max_type_value)
+    gen_type_to_object_id(out, "group_mod_type_to_id", "OF_GROUP_MOD",
+                          "OF_GROUP_%s", type_maps.group_mod_types,
                           max_type_value)
 
     # FIXME:  Multipart re-organization
@@ -504,6 +511,7 @@ of_message_to_object_id(of_message_t msg, int length) {
     uint16_t err_type;
     uint8_t flow_mod_cmd;
     uint32_t experimenter, subtype;
+    uint16_t group_mod_cmd;
 
     if (length < OF_MESSAGE_MIN_LENGTH) {
         return OF_OBJECT_INVALID;
@@ -568,6 +576,14 @@ of_message_to_object_id(of_message_t msg, int length) {
         }
         err_type = of_message_error_type_get(msg);
         obj_id = of_error_msg_to_object_id(err_type, ver);
+    }
+
+    if (obj_id == OF_GROUP_MOD) {
+        if (length < OF_MESSAGE_MIN_GROUP_MOD_LENGTH) {
+            return OF_OBJECT_INVALID;
+        }
+        group_mod_cmd = of_message_group_mod_command_get(msg);
+        obj_id = of_group_mod_to_object_id(group_mod_cmd, ver);
     }
 
     return obj_id;
@@ -691,6 +707,11 @@ of_oxm_to_object_id(uint32_t type_len, of_version_t version)
     ar_len = type_maps.type_array_len(type_maps.flow_mod_types, max_type_value)
     out.write(map_template %
               dict(name="flow_mod", u_name="FLOW_MOD", ar_len=ar_len))
+
+    ar_len = type_maps.type_array_len(type_maps.group_mod_types,
+                                      max_type_value)
+    out.write(map_template %
+              dict(name="group_mod", u_name="GROUP_MOD", ar_len=ar_len))
 
     # OXM
     ar_len = type_maps.type_array_len(type_maps.oxm_types, max_type_value)
@@ -947,6 +968,48 @@ of_object_to_flow_mod_command(of_object_id_t id, of_version_t version)
 
 """)
 
+    ################################################################
+    # Generate object ID to the group mod sub-type map
+    ################################################################
+
+    out.write("""
+/**
+ * Map an object ID to a group-mod command value
+ * @param id An object ID
+ * @return The wire value for the group-mod command
+ * @return -1 if not supported for this version
+ * @return -1 if id is not a specific stats type ID
+ *
+ * Note that the value is returned as a signed integer.  So -1 is
+ * an error code, while 0xffff is the usual "experimenter" code.
+ */
+
+static inline int
+of_object_to_group_mod_command(of_object_id_t id, of_version_t version)
+{
+    if (!OF_VERSION_OKAY(version)) {
+        return -1;
+    }
+    switch (id) {""")
+    group_mod_names = set()
+    for ver in of_g.of_version_range:
+        for name in type_maps.group_mod_types[ver]:
+            group_mod_names.add(name)
+    for name in group_mod_names:
+        out.write("""
+    case OF_GROUP_%(name)s:
+        if (OF_GROUP_MOD_COMMAND_%(name)s_SUPPORTED(version))
+            return OF_GROUP_MOD_COMMAND_%(name)s_BY_VERSION(version);
+        break;""" % {"name": name.upper()})
+    out.write("""
+    default:
+        break;
+    }
+    return -1; /* Not recognized as group mod type object for this version */
+}
+
+""")
+
 def gen_type_maps_header(out):
     """
     Generate various header file declarations for type maps
@@ -1088,6 +1151,10 @@ of_wire_message_object_id_set(of_wire_buffer_t *wbuf, of_object_id_t id)
     if ((type = of_object_to_flow_mod_command(id, ver)) >= 0) {
         /* It's a flow mod obj */
         of_message_flow_mod_command_set(msg, ver, type);
+    }
+    if ((type = of_object_to_group_mod_command(id, ver)) >= 0) {
+        /* It's a group mod obj */
+        of_message_group_mod_command_set(msg, type);
     }
     if (of_object_id_is_extension(id, ver)) {
         uint32_t val32;

--- a/c_gen/of_g_legacy.py
+++ b/c_gen/of_g_legacy.py
@@ -99,7 +99,7 @@ code_gen_config = dict(
 ## These members do not get normal accessors
 
 skip_members = ["version", "type", "length", "err_type", "stats_type", "len",
-                "type_len", "actions_len", "_command"]
+                "type_len", "actions_len", "_command", "command"]
 
 ## Some OpenFlow string length constants
 #

--- a/c_gen/templates/of_message.h
+++ b/c_gen/templates/of_message.h
@@ -48,11 +48,13 @@ typedef uint8_t *of_message_t;
 #define OF_MESSAGE_ERROR_TYPE_OFFSET 8
 #define OF_MESSAGE_STATS_TYPE_OFFSET 8
 #define OF_MESSAGE_FLOW_MOD_COMMAND_OFFSET(version) ((version) == 1 ? 56 : 25)
+#define OF_MESSAGE_GROUP_MOD_COMMAND_OFFSET 8
 
 #define OF_MESSAGE_MIN_LENGTH 8
 #define OF_MESSAGE_MIN_STATS_LENGTH (OF_MESSAGE_STATS_TYPE_OFFSET + 2)
 #define OF_MESSAGE_MIN_ERROR_LENGTH (OF_MESSAGE_ERROR_TYPE_OFFSET + 4)
 #define OF_MESSAGE_MIN_FLOW_MOD_LENGTH(version)  ((version) == 1 ? 57 : 26)
+#define OF_MESSAGE_MIN_GROUP_MOD_LENGTH (OF_MESSAGE_GROUP_MOD_COMMAND_OFFSET + 2)
 
 #define OF_MESSAGE_EXPERIMENTER_ID_OFFSET 8
 #define OF_MESSAGE_EXPERIMENTER_SUBTYPE_OFFSET 12
@@ -310,6 +312,25 @@ of_message_stats_experimenter_subtype_get(of_message_t msg) {
 static inline void
 of_message_stats_experimenter_subtype_set(of_message_t msg, uint32_t subtype) {
     buf_u32_set(msg + OF_MESSAGE_STATS_EXPERIMENTER_SUBTYPE_OFFSET, subtype);
+}
+
+/**
+ * @brief Get/set group mod command of a message
+ * @param msg Pointer to the message buffer of sufficient length
+ * @param subtype Data for set operation
+ * @returns get returns command in host order
+ */
+
+static inline uint16_t
+of_message_group_mod_command_get(of_message_t msg) {
+    uint16_t val;
+    buf_u16_get(msg + OF_MESSAGE_GROUP_MOD_COMMAND_OFFSET, &val);
+    return val;
+}
+
+static inline void
+of_message_group_mod_command_set(of_message_t msg, uint16_t command) {
+    buf_u16_set(msg + OF_MESSAGE_GROUP_MOD_COMMAND_OFFSET, command);
 }
 
 #endif /* _OF_MESSAGE_H_ */

--- a/c_gen/translation.py
+++ b/c_gen/translation.py
@@ -89,7 +89,7 @@ def loxi_name(ident):
         dict(OFPM_ = "OF_METER_"),
         dict(OFPXMC_ = "OF_OXM_CLASS_"),
         dict(OFPVID_ = "OF_VLAN_TAG_"),
-        dict(OFPGC_ = "OF_GROUP_"),
+        dict(OFPGC_ = "OF_GROUP_MOD_COMMAND_"),
         dict(OFPGT_ = "OF_GROUP_TYPE_"),
         dict(OFPG_ = "OF_GROUP_"),
         dict(OFPET_ = "OF_ERROR_TYPE_"),

--- a/c_gen/type_maps.py
+++ b/c_gen/type_maps.py
@@ -156,7 +156,7 @@ def class_is_virtual(cls):
     if loxi_utils.class_is_list(cls):
         return True
     # TODO get this from the input file when we have virtual class syntax
-    if cls in ["of_flow_mod", "of_stats_request", "of_stats_reply", "of_error_msg", "of_bsn_header", "of_nicira_header", "of_action_bsn", "of_action_nicira", "of_action_id_bsn", "of_action_id_nicira", "of_bsn_stats_request", "of_bsn_stats_reply", "of_experimenter_stats_request", "of_experimenter_stats_reply", "of_instruction_experimenter", "of_instruction_bsn"]:
+    if cls in ["of_flow_mod", "of_stats_request", "of_stats_reply", "of_error_msg", "of_bsn_header", "of_nicira_header", "of_action_bsn", "of_action_nicira", "of_action_id_bsn", "of_action_id_nicira", "of_bsn_stats_request", "of_bsn_stats_reply", "of_experimenter_stats_request", "of_experimenter_stats_reply", "of_instruction_experimenter", "of_instruction_bsn", "of_group_mod"]:
         return True
     return False
 
@@ -182,6 +182,7 @@ message_types = {
         error_msg               = 1,
         experimenter            = 4,
         flow_mod                = 14,
+        group_mod               = 15,
         stats_request           = 18,
         stats_reply             = 19,
         ),
@@ -191,6 +192,7 @@ message_types = {
         error_msg               = 1,
         experimenter            = 4,
         flow_mod                = 14,
+        group_mod               = 15,
         stats_request           = 18,
         stats_reply             = 19,
         ),
@@ -200,6 +202,7 @@ message_types = {
         error_msg               = 1,
         experimenter            = 4,
         flow_mod                = 14,
+        group_mod               = 15,
         stats_request           = 18,  # FIXME Multipart
         stats_reply             = 19,
         )
@@ -350,6 +353,32 @@ error_types = {
         meter_mod_failed     = 12,
         table_features_failed= 13,
         experimenter = 0xffff
+        )
+    }
+
+group_mod_types = {
+    # version 1.0
+    of_g.VERSION_1_0:dict(),
+
+    # version 1.1
+    of_g.VERSION_1_1:dict(
+        add = 0,
+        modify = 1,
+        delete = 2
+        ),
+
+    # version 1.2
+    of_g.VERSION_1_2:dict(
+        add = 0,
+        modify = 1,
+        delete = 2
+        ),
+
+    # version 1.3
+    of_g.VERSION_1_3:dict(
+        add = 0,
+        modify = 1,
+        delete = 2
         )
     }
 
@@ -505,6 +534,12 @@ error_msg_list = [
     "of_meter_mod_failed_error_msg",
     "of_table_features_failed_error_msg",
     "of_experimenter_error_msg"
+]
+
+group_mod_list = [
+    "of_group_add",
+    "of_group_modify",
+    "of_group_delete",
 ]
 
 def sub_class_map(base_type, version):


### PR DESCRIPTION
Reviewer: @andi-bigswitch

I wanted to use the real IR inside loci to begin rewriting the wire type
mess, but hiding the group mod subclasses was getting in the way.
