### PR TITLE
java_gen: dedicated factories for (action|instruction)_id, erromsg

### DIFF
--- a/java_gen/java_model.py
+++ b/java_gen/java_model.py
@@ -201,7 +201,7 @@ class JavaModel(object):
 
         factories = OrderedDict()
 
-        sub_factory_classes = ("OFAction", "OFInstruction", "OFMeterBand", "OFOxm", "OFQueueProp")
+        sub_factory_classes = ("OFAction", "OFInstruction", "OFMeterBand", "OFOxm", "OFQueueProp", "OFErrorMsg", "OFActionId", "OFInstructionId")
         for base_class in sub_factory_classes:
             package = base_class[2:].lower()
             remove_prefix = base_class[2].lower() + base_class[3:]
@@ -210,7 +210,7 @@ class JavaModel(object):
             annotated_base_class = base_class + "<?>" if base_class == "OFOxm" else base_class
 
             factories[base_class] = OFFactory(package="%s.%s" % (prefix, package),
-                    name=base_class + "s", members=[], remove_prefix=remove_prefix, base_class=annotated_base_class, sub_factories={}, xid_generator=False)
+                    name=base_class + "s", members=[], remove_prefix=remove_prefix, base_class=annotated_base_class, sub_factories={}, xid_generator= (base_class == "OFErrorMsg"))
 
         factories[""] = OFFactory(
                     package=prefix,
@@ -446,7 +446,7 @@ class JavaOFInterface(object):
             else:
                 return ("", "OFStatsReply", None)
         elif self.ir_class.is_subclassof('of_error_msg'):
-            return ("", "OFErrorMsg", None)
+            return ("errormsg", "OFErrorMsg", None)
         elif self.ir_class.is_subclassof('of_flow_mod'):
             return ("", "OFFlowMod", None)
         elif self.ir_class.is_subclassof('of_group_mod'):

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.projectfloodlight</groupId>
     <artifactId>openflowj</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>OpenFlowJ-Loxi</name>

--- a/java_gen/templates/_imports.java
+++ b/java_gen/templates/_imports.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.projectfloodlight.openflow.protocol.*;
 import org.projectfloodlight.openflow.protocol.action.*;
 import org.projectfloodlight.openflow.protocol.actionid.*;
+import org.projectfloodlight.openflow.protocol.errormsg.*;
 import org.projectfloodlight.openflow.protocol.meterband.*;
 import org.projectfloodlight.openflow.protocol.instruction.*;
 import org.projectfloodlight.openflow.protocol.instructionid.*;


### PR DESCRIPTION
Reviewer: @vaterlaus @rlane

also moved the errormsg subclasses to their own package (errormsg)
bumped openflowj version to 0.3.2
