### PR TITLE
loci: fix 32-bit build

### DIFF
--- a/c_gen/codegen.py
+++ b/c_gen/codegen.py
@@ -59,7 +59,7 @@ def gen_push_wire_types(install_dir):
                         # Special case for version
                         pwtms.append(PushWireTypesMember(m.name, m.offset, m.length, "obj->version"))
                     else:
-                        pwtms.append(PushWireTypesMember(m.name, m.offset, m.length, m.value))
+                        pwtms.append(PushWireTypesMember(m.name, m.offset, m.length, hex(m.value)))
             type_members_by_version[version] = pwtms
 
         # Merge versions with identical type members

--- a/test_data/of10/packet_in.data
+++ b/test_data/of10/packet_in.data
@@ -18,7 +18,7 @@ ofp.message.packet_in(
     data='abc')
 -- c
 obj = of_packet_in_new(OF_VERSION_1_0);
-of_packet_in_buffer_id_set(obj, 2882400001);
+of_packet_in_buffer_id_set(obj, 0xabcdef01);
 {
     of_octets_t data = { .bytes=3, .data=(uint8_t *)"\x61\x62\x63" };
     of_packet_in_data_set(obj, &data);

--- a/test_data/of10/packet_out.data
+++ b/test_data/of10/packet_out.data
@@ -25,7 +25,7 @@ ofp.message.packet_out(
     data='abc')
 -- c
 obj = of_packet_out_new(OF_VERSION_1_0);
-of_packet_out_buffer_id_set(obj, 2882400001);
+of_packet_out_buffer_id_set(obj, 0xabcdef01);
 of_packet_out_in_port_set(obj, 65534);
 of_packet_out_xid_set(obj, 305419896);
 {

--- a/test_data/of10/port_mod.data
+++ b/test_data/of10/port_mod.data
@@ -18,12 +18,12 @@ ofp.message.port_mod(
     advertise=0xCAFE6789)
 -- c
 obj = of_port_mod_new(OF_VERSION_1_0);
-of_port_mod_advertise_set(obj, 3405670281);
-of_port_mod_config_set(obj, 2427178479);
+of_port_mod_advertise_set(obj, 0xCAFE6789);
+of_port_mod_config_set(obj, 0x90ABCDEF);
 {
     of_mac_addr_t hw_addr = { { 1, 2, 3, 4, 5, 6 } };
     of_port_mod_hw_addr_set(obj, hw_addr);
 }
-of_port_mod_mask_set(obj, 4279369489);
+of_port_mod_mask_set(obj, 0xFF11FF11);
 of_port_mod_port_no_set(obj, 65533);
 of_port_mod_xid_set(obj, 2);


### PR DESCRIPTION
Reviewer: trivial

GCC warned "this decimal constant is unsigned only in ISO C90" for large 32-bit
constants. Fixed by writing them in hex.
