### PR TITLE
java_gen: fix OFMatchV1Ver10.isPartiallyMasked

### DIFF
--- a/java_gen/templates/custom/OFMatchV1Ver10.java
+++ b/java_gen/templates/custom/OFMatchV1Ver10.java
@@ -328,7 +328,7 @@
                 return srcCidrLen > 0 && srcCidrLen < 32;
             case ARP_TPA:
             case IPV4_DST:
-                int dstCidrLen = getIpv4SrcCidrMaskLen();
+                int dstCidrLen = getIpv4DstCidrMaskLen();
                 return dstCidrLen > 0 && dstCidrLen < 32;
             default:
                 throw new UnsupportedOperationException("OFMatch does not support masked matching on field " + field.getName());


### PR DESCRIPTION
Reviewer: @andi-bigswitch

This function was using `getIpv4SrcCidrMaskLen` when checking the IPV4_DST 
mask.
