### PR TITLE
java_gen: bump version to 0.3.4

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.projectfloodlight</groupId>
     <artifactId>openflowj</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>OpenFlowJ-Loxi</name>


### PR DESCRIPTION
Reviewer: trivial

The recent API correction breaks an existing use in bvs, so need to
bump the version.
