### PR TITLE
java_gen: use auto-generated reader/writer code for OFBsnVportQInQ

### DIFF
--- a/java_gen/java_type.py
+++ b/java_gen/java_type.py
@@ -418,6 +418,9 @@ oxm_list = JType("OFOxmList") \
 meter_features = JType("OFMeterFeatures")\
         .op(read="OFMeterFeaturesVer$version.READER.readFrom(bb)",
             write="$name.writeTo(bb)")
+bsn_vport_q_in_q = JType("OFBsnVportQInQ")\
+        .op(read="OFBsnVportQInQVer$version.READER.readFrom(bb)",
+            write="$name.writeTo(bb)")
 flow_wildcards = JType("int") \
         .op(read='bb.readInt()',
             write='bb.writeInt($name)',
@@ -523,6 +526,7 @@ default_mtype_to_jtype_convert_map = {
         'of_meter_features_t': meter_features,
         'of_bitmap_128_t': port_bitmap,
         'of_checksum_128_t': checksum,
+        'of_bsn_vport_q_in_q_t': bsn_vport_q_in_q,
         }
 
 ## Map that defines exceptions from the standard loxi->java mapping scheme

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver10/ChannelUtilsVer10.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver10/ChannelUtilsVer10.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFActionType;
-import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
 import org.projectfloodlight.openflow.protocol.match.Match;
 
 import com.google.common.hash.PrimitiveSink;
@@ -20,17 +19,6 @@ import com.google.common.hash.PrimitiveSink;
 public class ChannelUtilsVer10 {
     public static Match readOFMatch(final ChannelBuffer bb) throws OFParseError {
         return OFMatchV1Ver10.READER.readFrom(bb);
-    }
-
-    // TODO these need to be figured out / removed
-    public static OFBsnVportQInQ readOFBsnVportQInQ(ChannelBuffer bb) {
-        throw new UnsupportedOperationException("not implemented");
-    }
-
-    public static void writeOFBsnVportQInQ(ChannelBuffer bb,
-            OFBsnVportQInQ vport) {
-        throw new UnsupportedOperationException("not implemented");
-
     }
 
     public static Set<OFActionType> readSupportedActions(ChannelBuffer bb) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver11/ChannelUtilsVer11.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver11/ChannelUtilsVer11.java
@@ -4,8 +4,6 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
-import org.projectfloodlight.openflow.protocol.ver11.OFMatchV2Ver11;
-import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
 
 /**
  * Collection of helper functions for reading and writing into ChannelBuffers
@@ -17,17 +15,6 @@ public class ChannelUtilsVer11 {
     public static Match readOFMatch(final ChannelBuffer bb) throws OFParseError {
         return OFMatchV2Ver11.READER.readFrom(bb);
     }
-
-    // TODO these need to be figured out / removed
-    public static OFBsnVportQInQ readOFBsnVportQInQ(ChannelBuffer bb) {
-        throw new UnsupportedOperationException("not implemented");
-    }
-
-    public static void writeOFBsnVportQInQ(ChannelBuffer bb,
-            OFBsnVportQInQ vport) {
-        throw new UnsupportedOperationException("not implemented");
-    }
-
 
     public static OFMatchBmap readOFMatchBmap(ChannelBuffer bb) {
         throw new UnsupportedOperationException("not implemented");

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver13/ChannelUtilsVer13.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver13/ChannelUtilsVer13.java
@@ -4,8 +4,6 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
-import org.projectfloodlight.openflow.protocol.ver13.OFMatchV3Ver13;
-import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
 
 /**
  * Collection of helper functions for reading and writing into ChannelBuffers
@@ -16,17 +14,6 @@ import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
 public class ChannelUtilsVer13 {
     public static Match readOFMatch(final ChannelBuffer bb) throws OFParseError {
         return OFMatchV3Ver13.READER.readFrom(bb);
-    }
-
-    // TODO these need to be figured out / removed
-
-    public static OFBsnVportQInQ readOFBsnVportQInQ(ChannelBuffer bb) {
-        throw new UnsupportedOperationException("not implemented");
-    }
-
-    public static void writeOFBsnVportQInQ(ChannelBuffer bb,
-            OFBsnVportQInQ vport) {
-        throw new UnsupportedOperationException("not implemented");
     }
 
     public static OFMatchBmap readOFMatchBmap(ChannelBuffer bb) {


### PR DESCRIPTION
Reviewer: @shudong @rlane

This commit removes the unimplemented manual stub methods for reading
and writing OFBsnVportQInq from ChannelUtilsVer${version}. Instead,
it delegates the OP to the auto-generated reader and writer.
