### PR TITLE
openflowj: upgrade netty to 3.9.0

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -52,9 +52,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.netty</groupId>
+            <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.2.9.Final</version>
+            <version>3.9.0.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Reviewer: @vaterlaus

This PR updates the netty dependency in openflowj to 3.9.0
