### PR TITLE
java_gen: Return copies of byte arrays in getBytes LOXI-58

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
@@ -1,5 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
+import java.util.Arrays;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 
 import com.google.common.hash.PrimitiveSink;
@@ -133,7 +135,7 @@ public class IPv4Address extends IPAddress<IPv4Address> {
                 }
             }
         }
-        return bytesCache.clone();
+        return Arrays.copyOf(bytesCache, bytesCache.length);
     }
 
     @Override

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
@@ -1,9 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
+
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Longs;
 
@@ -228,7 +230,7 @@ public class IPv6Address extends IPAddress<IPv6Address> {
                 }
             }
         }
-        return bytesCache.clone();
+        return Arrays.copyOf(bytesCache, bytesCache.length);
     }
 
     @Override

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
@@ -1,5 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
+import java.util.Arrays;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.util.HexString;
@@ -95,7 +97,7 @@ public class MacAddress implements OFValueType<MacAddress> {
                 }
             }
         }
-        return bytesCache.clone();
+        return Arrays.copyOf(bytesCache, bytesCache.length);
     }
 
     /**

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFVlanVidMatch.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFVlanVidMatch.java
@@ -1,5 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
+import java.util.Arrays;
+
 import javax.annotation.Nullable;
 
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -155,7 +157,7 @@ public class OFVlanVidMatch implements OFValueType<OFVlanVidMatch> {
                 }
             }
         }
-        return bytesCache.clone();
+        return Arrays.copyOf(bytesCache, bytesCache.length);
     }
 
     public void write2Bytes(ChannelBuffer c) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VlanVid.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VlanVid.java
@@ -1,5 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
+import java.util.Arrays;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
@@ -79,7 +81,7 @@ public class VlanVid implements OFValueType<VlanVid> {
                 }
             }
         }
-        return bytesCache.clone();
+        return Arrays.copyOf(bytesCache, bytesCache.length);
     }
 
     public void write2Bytes(ChannelBuffer c) {


### PR DESCRIPTION
Reviewer: @gregor-bsn

The getBytes() methods of various classes in openflow.types were
returning and caching instances of byte[], which is mutable. They
now return clone()'d instances.
