### PR TITLE
loci: add a function to parse messages without allocating memory

### DIFF
--- a/c_gen/templates/locitest/test_utils.c
+++ b/c_gen/templates/locitest/test_utils.c
@@ -118,10 +118,32 @@ test_has_outport(void)
     return TEST_PASS;
 }
 
+static int
+test_of_object_new_from_message_preallocated(void)
+{
+    /* v1 OFPT_HELLO, xid=0x12345678 */
+    uint8_t buf[] = { 0x01, 0x00, 0x00, 0x08, 0x12, 0x34, 0x56, 0x78 };
+
+    of_object_storage_t storage;
+    of_object_t *obj = of_object_new_from_message_preallocated(
+        &storage, buf, sizeof(buf));
+
+    TEST_ASSERT(obj != NULL);
+    TEST_ASSERT(obj->version = OF_VERSION_1_0);
+    TEST_ASSERT(obj->object_id = OF_HELLO);
+
+    uint32_t xid;
+    of_hello_xid_get(obj, &xid);
+    TEST_ASSERT(xid == 0x12345678);
+
+    return TEST_PASS;
+}
+
 int
 run_utility_tests(void)
 {
     RUN_TEST(has_outport);
+    RUN_TEST(of_object_new_from_message_preallocated);
     RUN_TEST(dump_objs);
 
     return TEST_PASS;

--- a/c_gen/templates/of_object.h
+++ b/c_gen/templates/of_object.h
@@ -122,6 +122,11 @@ extern int of_object_append_buffer(of_object_t *dst, of_object_t *src);
 
 extern of_object_t *of_object_new_from_message(of_message_t msg, int len);
 
+typedef struct of_object_storage_s of_object_storage_t;
+
+of_object_t *of_object_new_from_message_preallocated(
+    of_object_storage_t *storage, uint8_t *buf, int len);
+
 /* Delete an OpenFlow object without reference to its type */
 extern void of_object_delete(of_object_t *obj);
 
@@ -167,6 +172,11 @@ struct of_object_s {
      * or inspected by LOCI.
      */
     uint64_t metadata[(OF_OBJECT_METADATA_BYTES + 7) / 8];
+};
+
+struct of_object_storage_s {
+    of_object_t obj;
+    of_wire_buffer_t wbuf;
 };
 
 #endif /* _OF_OBJECT_H_ */


### PR DESCRIPTION
Reviewer: @wilmo119

This will be used by the Indigo connection manager to parse messages directly 
from the read buffer, saving three allocations and a memcpy.
