### PR TITLE
loci: chunk multiple classes into each C file

### DIFF
--- a/generic_utils.py
+++ b/generic_utils.py
@@ -214,3 +214,11 @@ def count(func, iteratable):
         if func(i):
             c +=1
     return c
+
+def chunks(l, n):
+    """
+    Yield successive n-sized chunks from l.
+    From http://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks-in-python
+    """
+    for i in xrange(0, len(l), n):
+        yield l[i:i+n]


### PR DESCRIPTION
Reviewer: @andi-bigswitch

Parsing headers was taking more than half of the compile time for many
classes. By putting multiple classes into a single C file we amortize the cost
of header parsing. These C files are still much smaller than the old loci.c.

I also experimented with chunking the list and header class files, but there 
are relatively few of these and so there was little gain.

The code size reduction is presumably due to better sharing of code between 
similar classes. Since the classes are sorted by name before chunking the 
action, instruction, etc inheritance hierarchies will be grouped together.

Results: time make -j4 loci.a: -44% (27.4s to 15.4s) strip loci.a && du -sh
loci.a: -25% (2.3 MB to 1.7 MB)
