### PR TITLE
openflow_input: remove redundant of_experimenter_stats_header

### DIFF
--- a/openflow_input/standard-1.3
+++ b/openflow_input/standard-1.3
@@ -1993,11 +1993,6 @@ struct of_meter_config {
     list(of_meter_band_t) entries;
 };
 
-struct of_experimenter_stats_header {
-    uint32_t experimenter == ?;
-    uint32_t subtype;
-};
-
 // END OF STATS OBJECTS
 
 struct of_queue_prop {


### PR DESCRIPTION
Reviewer: trivial

Fixes https://github.com/floodlight/loxigen-artifacts/issues/1
