### PR TITLE
ICMPv4Type and ICMPv4Code cannot be converted into TransportPort. Thus, ...

### DIFF
--- a/java_gen/templates/custom/OFMatchV1Ver10.Builder.java
+++ b/java_gen/templates/custom/OFMatchV1Ver10.Builder.java
@@ -319,11 +319,11 @@
                     wildcards &= ~OFPFW_DL_TYPE;
                     break;
                 case ICMPV4_CODE:
-                    setTcpDst((TransportPort) value);
+                    setTcpDst(TransportPort.of(((ICMPv4Code)value).getCode()));
                     wildcards &= ~OFPFW_TP_DST;
                     break;
                 case ICMPV4_TYPE:
-                    setTcpSrc((TransportPort) value);
+                    setTcpSrc(TransportPort.of(((ICMPv4Type)value).getType()));
                     wildcards &= ~OFPFW_TP_SRC;
                     break;
                 case IN_PORT:


### PR DESCRIPTION
...the manual conversion code is inserted.
