### PR TITLE
OFVlanVidMatch: enable correct conversion of VlanVid.NO_MASK

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFVlanVidMatch.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFVlanVidMatch.java
@@ -74,7 +74,14 @@ public class OFVlanVidMatch implements OFValueType<OFVlanVidMatch> {
     }
 
     public static OFVlanVidMatch ofVlanVid(VlanVid vid) {
-        return ofVlan(vid.getVlan());
+        if(vid == null)
+            return UNTAGGED;
+        else if(VlanVid.NO_MASK.equals(vid))
+            // NO_MASK is a special value in that it doesn't fit in the
+            // allowed value space (0x1FFF) of this type. Do a manual conversion
+            return NO_MASK;
+        else
+            return ofVlan(vid.getVlan());
     }
 
 
@@ -110,7 +117,12 @@ public class OFVlanVidMatch implements OFValueType<OFVlanVidMatch> {
      */
     @Nullable
     public VlanVid getVlanVid() {
-        return isPresentBitSet() ? VlanVid.ofVlan((short) (vid & VLAN_MASK)) : null;
+        if(this.equals(NO_MASK))
+            return VlanVid.NO_MASK;
+        else if(isPresentBitSet())
+            return VlanVid.ofVlan((short) (vid & VLAN_MASK));
+        else
+            return null;
     }
 
     @Override

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFVlanVidMatchTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFVlanVidMatchTest.java
@@ -1,0 +1,44 @@
+package org.projectfloodlight.openflow.types;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class OFVlanVidMatchTest {
+    @Test
+    public void testofVlanVid() {
+        assertThat(
+                (int) OFVlanVidMatch.ofVlanVid(VlanVid.ofVlan(1)).getRawVid(),
+                equalTo(0x1001));
+        assertThat(
+                (int) OFVlanVidMatch.ofVlanVid(VlanVid.ofVlan(0xFFF)).getRawVid(),
+                equalTo(0x1FFF));
+        assertThat(OFVlanVidMatch.ofVlanVid(null), equalTo(OFVlanVidMatch.UNTAGGED));
+        assertThat(OFVlanVidMatch.ofVlanVid(VlanVid.NO_MASK),
+                equalTo(OFVlanVidMatch.NO_MASK));
+        // a fully masked VlanVid means "PRESENT" in OFVlanVid
+        // (because a VlanVid always specifies a Vlan)
+        assertThat(OFVlanVidMatch.ofVlanVid(VlanVid.FULL_MASK),
+                equalTo(OFVlanVidMatch.PRESENT));
+    }
+    @Test
+    public void testtoVlanVid() {
+        assertThat(
+                OFVlanVidMatch.ofRawVid((short)0x1001).getVlanVid(),
+                                        equalTo(VlanVid.ofVlan(1)));
+        assertThat(
+                OFVlanVidMatch.ofRawVid((short)0x1FFF).getVlanVid(),
+                                        equalTo(VlanVid.ofVlan(0xFFF)));
+        assertThat(OFVlanVidMatch.UNTAGGED.getVlanVid(), CoreMatchers.nullValue());
+        assertThat(
+                OFVlanVidMatch.NO_MASK.getVlanVid(),
+                                        equalTo(VlanVid.NO_MASK));
+        assertThat(
+                OFVlanVidMatch.PRESENT.getVlanVid(),
+                                        equalTo(VlanVid.FULL_MASK));
+    }
+
+
+}


### PR DESCRIPTION
Reviewer: @kwanggithub @ronaldchl

Also fixed consistency of null value handling with VlanVid.
- added unit test
