### PR TITLE
loci: fix compilation with GCC <= 4.4

### DIFF
--- a/c_gen/templates/loci_int.h
+++ b/c_gen/templates/loci_int.h
@@ -46,7 +46,7 @@
 
 #include <loci/loci.h>
 
-#ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define UNREACHABLE() __builtin_unreachable()
 #else
 #define UNREACHABLE()


### PR DESCRIPTION
Reviewer: trivial

The __builtin_unreachable macro was introduced in GCC 4.5.
