### PR TITLE
openflow_input: add bsn_vrf TLV

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -152,5 +152,5 @@ struct of_bsn_tlv_udf_length : of_bsn_tlv {
 struct of_bsn_tlv_vrf : of_bsn_tlv {
     uint16_t type == 19;
     uint16_t length;
-    uint16_t value;
+    uint32_t value;
 };


### PR DESCRIPTION
This bsn_vrf is used in the dhcp relay table.

Reviewer: @rlane
