### PR TITLE
loci: only mask partially wildcarded fields

### DIFF
--- a/c_gen/c_match.py
+++ b/c_gen/c_match.py
@@ -177,27 +177,19 @@ typedef struct of_match_s {
     of_match_fields_t masks;
 } of_match_t;
 
-/**
- * Mask the values in the match structure according to its fields
+/*
+ * AND 'len' bytes starting from 'value' with the corresponding byte in
+ * 'mask'.
  */
-static inline void of_match_values_mask(of_match_t *match)
-{
-    int idx;
-
-    for (idx = 0; idx < sizeof(of_match_fields_t); idx++) {
-        ((uint8_t *)&match->fields)[idx] &= ((uint8_t *)&match->masks)[idx];
-    }
-}
-
 static inline void
-of_memmask(void *_fields, void *_masks, size_t len)
+of_memmask(void *value, const void *mask, size_t len)
 {
-    int idx;
-    uint8_t *fields = _fields;
-    uint8_t *masks = _masks;
+    int i;
+    uint8_t *v = value;
+    const uint8_t *m = mask;
 
-    for (idx = 0; idx < len; idx++) {
-        fields[idx] &= masks[idx];
+    for (i = 0; i < len; i++) {
+        v[i] &= m[i];
     }
 }
 

--- a/c_gen/c_test_gen.py
+++ b/c_gen/c_test_gen.py
@@ -272,7 +272,7 @@ of_match_populate(of_match_t *match, of_version_t version, int value)
     }
 
     /* Restrict values according to masks */
-    of_match_values_mask(match);
+    of_memmask(&match->fields, &match->masks, sizeof(match->fields));
     return value;
 }
 


### PR DESCRIPTION
Reviewer: @ducwindow

The of_match_values_mask function was consuming about 7% CPU time in my 
benchmarks. For realistic flows most of the work it did was pointless, because 
most fields are fully wildcarded and most of the rest are not wildcarded. Only 
in the uncommon case of partially wildcarded fields does this function do 
anything.

Fixed by calling a new of_memmask function only when parsing a masked OXM.
