### PR TITLE
loci: workaround a clang analyzer warning

### DIFF
--- a/c_gen/templates/loci_validator.c
+++ b/c_gen/templates/loci_validator.c
@@ -110,8 +110,11 @@ ${validator_name(ofclass)}(uint8_t *data, int len, int *out_len)
         return -1;
     }
 
+:: if not ofclass.is_fixed_length:
     len = wire_len;
 
+:: #endif
+::
 :: elif type(m) == OFFieldLengthMember:
 :: # Read field length members
 :: field_length_members[m.field_name] = m


### PR DESCRIPTION
Reviewer: trivial

Clang figured out that in the case of a fixed-length object the `len = 
wire_len` assignment was redundant.
