### PR TITLE
Add OFP_BSN_PKTIN_FLAG_INGRESS_ACL pktin flag.

### DIFF
--- a/openflow_input/bsn_pktin_flag
+++ b/openflow_input/bsn_pktin_flag
@@ -42,4 +42,5 @@ enum ofp_bsn_pktin_flag(wire_type=uint64_t, bitmask=True) {
     OFP_BSN_PKTIN_FLAG_TTL_EXPIRED = 0x80,
     OFP_BSN_PKTIN_FLAG_L3_MISS = 0x100,
     OFP_BSN_PKTIN_FLAG_L3_CPU = 0x200,
+    OFP_BSN_PKTIN_FLAG_INGRESS_ACL = 0x400,
 };


### PR DESCRIPTION
Reviewer: @rlane

This lets us differentiate packet-ins from the ingress ACL table.
