### PR TITLE
java/OFErrorCauseData: fix regression - URGENT

### DIFF
--- a/java_gen/java_type.py
+++ b/java_gen/java_type.py
@@ -502,7 +502,7 @@ gen_table_id = JType("GenTableId") \
 udf = JType("UDF") \
          .op(version=ANY, read="UDF.read4Bytes(bb)", write="$name.write4Bytes(bb)", default="UDF.ZERO")
 error_cause_data = JType("OFErrorCauseData") \
-         .op(version=ANY, read="OFErrorCauseData.read(bb, $length, OFVersion.OF_$version)", write="$name.writeTo(bb)");
+         .op(version=ANY, read="OFErrorCauseData.read(bb, $length, OFVersion.OF_$version)", write="$name.writeTo(bb)", default="OFErrorCauseData.NONE");
 
 generic_t = JType("T")
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFErrorCauseData.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFErrorCauseData.java
@@ -30,6 +30,12 @@ public class OFErrorCauseData implements Writeable, PrimitiveSinkable {
     private static final Logger logger =
             LoggerFactory.getLogger(OFErrorCauseData.class);
 
+    /** A default 'empty' cause. Note: the OFVersion OF_13 passed in here is irrelevant,
+     *  because parsing of the 0-byte array will always return null, irrespective of the
+     *  version.
+     */
+    public static final OFErrorCauseData NONE = new OFErrorCauseData(new byte[0], OFVersion.OF_13);
+
     private final byte[] data;
     private final OFVersion version;
 


### PR DESCRIPTION
Reviewer: @vaterlaus @ronaldchl

This pull request fixes a regression introduced in #263 commit 62cbcff.

the new OFErroCauseData did not have a default value which broke existing
floodlight unit tests.
