### PR TITLE
java/OFMatchV3Ver13: bugfix for MatchFieldIterator

### DIFF
--- a/java_gen/templates/_imports.java
+++ b/java_gen/templates/_imports.java
@@ -26,6 +26,7 @@ import org.jboss.netty.buffer.ChannelBuffers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.common.hash.Funnel;
 import com.google.common.hash.PrimitiveSink;

--- a/java_gen/templates/custom/OFMatchV3Ver13.java
+++ b/java_gen/templates/custom/OFMatchV3Ver13.java
@@ -83,7 +83,7 @@
         return oxm != null && oxm.isMasked();
     }
 
-    private class MatchFieldIterator extends UnmodifiableIterator<MatchField<?>> {
+    private class MatchFieldIterator extends AbstractIterator<MatchField<?>> {
         private Iterator<OFOxm<?>> oxmIterator;
 
         MatchFieldIterator() {
@@ -91,14 +91,14 @@
         }
 
         @Override
-        public boolean hasNext() {
-            return oxmIterator.hasNext();
-        }
-
-        @Override
-        public MatchField<?> next() {
-            OFOxm<?> next = oxmIterator.next();
-            return next.getMatchField();
+        protected MatchField<?> computeNext() {
+            while(oxmIterator.hasNext()) {
+                OFOxm<?> oxm = oxmIterator.next();
+                if(oxm.getMatchField().arePrerequisitesOK(OFMatchV3Ver13.this))
+                   return oxm.getMatchField();
+            }
+            endOfData();
+            return null;
         }
     }
 


### PR DESCRIPTION
Reviewer: @ronaldchl

MatchFieldIterator would return match fields for which the
prerequisites were not met. Then the get() method for those
MatchFields would return null (hiding the fields).
This bug fix makes iterator() behave consistently with
get() / getMasked()
