### PR TITLE
loci: remove minimum wire buffer allocation size

### DIFF
--- a/c_gen/templates/of_wire_buf.h
+++ b/c_gen/templates/of_wire_buf.h
@@ -119,12 +119,6 @@ typedef struct of_wire_buffer_s {
 #define OF_OBJECT_TO_WBUF(obj) ((obj)->wbuf)
 
 
-
-/**
- * Minimum allocation size for wire buffer object
- */
-#define OF_WIRE_BUFFER_MIN_ALLOC_BYTES 128
-
 /**
  * Allocate a wire buffer object and the underlying data buffer.
  * The wire buffer is initally empty (current_bytes == 0).
@@ -141,10 +135,6 @@ of_wire_buffer_new(int a_bytes)
         return NULL;
     }
     MEMSET(wbuf, 0, sizeof(of_wire_buffer_t));
-
-    if (a_bytes < OF_WIRE_BUFFER_MIN_ALLOC_BYTES) {
-        a_bytes = OF_WIRE_BUFFER_MIN_ALLOC_BYTES;
-    }
 
     if ((wbuf->buf = (uint8_t *)MALLOC(a_bytes)) == NULL) {
         FREE(wbuf);


### PR DESCRIPTION
Reviewer: trivial

This hasn't been useful since writable wire buffers were changed to be 
allocated at maximum size. This code was causing excessive memory usage in 
Indigo when storing the instruction list, which is often only around 16 bytes. 
Removing this code saves us 17% memory usage and increases flow-add
performance by 9%.
