### PR TITLE
change checksum combination operation to addition

### DIFF
--- a/openflow_input/bsn_flow_checksum
+++ b/openflow_input/bsn_flow_checksum
@@ -33,7 +33,7 @@
 // Retrieves the checksum for every bucket in a table. The entries are ordered
 // by bucket index.
 //
-// The checksum of a bucket is the XOR of the cookies of all entries in the
+// The checksum of a bucket is the sum of the cookies of all entries in the
 // bucket. Flows are bucketed based on a prefix of the cookie.
 struct of_bsn_flow_checksum_bucket_stats_request : of_bsn_stats_request {
     uint8_t version;
@@ -68,7 +68,7 @@ struct of_bsn_flow_checksum_bucket_stats_reply : of_bsn_stats_reply {
 
 // Retrieves the checksum for every table.
 //
-// The checksum of a table is the XOR of the cookies of all entries in the
+// The checksum of a table is the sum of the cookies of all entries in the
 // table.
 struct of_bsn_table_checksum_stats_request : of_bsn_stats_request {
     uint8_t version;

--- a/openflow_input/bsn_gentable
+++ b/openflow_input/bsn_gentable
@@ -282,7 +282,7 @@ struct of_bsn_gentable_desc_stats_reply : of_bsn_stats_reply {
 // Retrieves stats for every table. This includes the total checksum, so the
 // controller can quickly check whether the whole table is in sync.
 //
-// The checksum of a table is the XOR of the checksums of all entries in the
+// The checksum of a table is the sum of the checksums of all entries in the
 // table.
 struct of_bsn_gentable_stats_request : of_bsn_stats_request {
     uint8_t version;
@@ -320,7 +320,7 @@ struct of_bsn_gentable_stats_reply : of_bsn_stats_reply {
 // Retrieves the checksum for every bucket in a table. The entries are ordered
 // by bucket index.
 //
-// The checksum of a bucket is the XOR of the checksums of all entries in the
+// The checksum of a bucket is the sum of the checksums of all entries in the
 // bucket.
 struct of_bsn_gentable_bucket_stats_request : of_bsn_stats_request {
     uint8_t version;


### PR DESCRIPTION
Reviewer: @andi-bigswitch

Addition/subtraction has advantages over XOR in that two adds of the same
value don't cancel each other out, and the high bits are better utilized.
