### PR TITLE
Cast InetAddress to Inet4Address or Inet6Address to call the specific static methods

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPAddress.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPAddress.java
@@ -142,9 +142,9 @@ public abstract class IPAddress<F extends IPAddress<F>> implements OFValueType<F
     public static IPAddress<?> of(@Nonnull InetAddress address) {
         Preconditions.checkNotNull(address, "address must not be null");
         if(address instanceof Inet4Address)
-            return IPv4Address.of(address);
+            return IPv4Address.of((Inet4Address) address);
         else if (address instanceof Inet6Address)
-            return IPv6Address.of(address);
+            return IPv6Address.of((Inet6Address) address);
         else
             return IPAddress.of(address.getHostAddress());
     }

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPAddressTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPAddressTest.java
@@ -1,10 +1,12 @@
 package org.projectfloodlight.openflow.types;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.junit.Test;
@@ -54,6 +56,28 @@ public class IPAddressTest {
         } catch (NullPointerException e) {
             assertNotNull(e.getMessage());
         }
+    }
+
+    @Test
+    public void testOfString() {
+        IPAddress<?> ip0 = IPAddress.of("1.2.3.4");
+        IPAddress<?> ip1 = IPAddress.of("abcd::1234");
+        assertTrue(ip0 instanceof IPv4Address);
+        assertTrue(ip1 instanceof IPv6Address);
+        assertEquals(ip0, IPv4Address.of("1.2.3.4"));
+        assertEquals(ip1, IPv6Address.of("abcd::1234"));
+    }
+
+    @Test
+    public void testOfInetAddress() throws Exception {
+        InetAddress ia0 = InetAddress.getByName("192.168.1.123");
+        InetAddress ia1 = InetAddress.getByName("fd00::4321");
+        IPAddress<?> ip0 = IPAddress.of(ia0);
+        IPAddress<?> ip1 = IPAddress.of(ia1);
+        assertTrue(ip0 instanceof IPv4Address);
+        assertTrue(ip1 instanceof IPv6Address);
+        assertEquals(ip0, IPv4Address.of(ia0));
+        assertEquals(ip1, IPv6Address.of(ia1));
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Reviewer: @andi-bigswitch @vaterlaus

Currently, the attempt to call the specific `IPv4Address.of(Inet4Address)` and `IPv6Address.of(Inet6Address)` turns out to be a recursive call without casting.
