### PR TITLE
openflow_input: remove subtype from OF 1.0 and 1.1 experimenter message

### DIFF
--- a/openflow_input/standard-1.0
+++ b/openflow_input/standard-1.0
@@ -341,7 +341,6 @@ struct of_experimenter : of_header {
     uint16_t length;
     uint32_t xid;
     uint32_t experimenter == ?;
-    uint32_t subtype;
     of_octets_t data;
 };
 

--- a/openflow_input/standard-1.1
+++ b/openflow_input/standard-1.1
@@ -447,7 +447,6 @@ struct of_experimenter : of_header {
     uint16_t length;
     uint32_t xid;
     uint32_t experimenter == ?;
-    uint32_t subtype;
     of_octets_t data;
 };
 


### PR DESCRIPTION
Reviewer: trivial

This field doesn't exist in the spec, and isn't necessarily 32 bits.

Fixes floodlight/loxigen#300.
