### PR TITLE
wireshark: make enums global instead of local

### DIFF
--- a/wireshark_gen/templates/openflow.lua
+++ b/wireshark_gen/templates/openflow.lua
@@ -52,7 +52,7 @@ local openflow_versions = {
 
 :: for version, ofproto in ir.items():
 :: for enum in ofproto.enums:
-local enum_v${version.wire_version}_${enum.name} = {
+enum_v${version.wire_version}_${enum.name} = {
 :: for (name, value) in enum.values:
     [${value}] = "${name}",
 :: #endfor


### PR DESCRIPTION
Reviewer: trivial

These were exceeding the limit of 200 locals with the standard-1.4 input file.

CC https://github.com/floodlight/loxigen/pull/311
