### PR TITLE
wireshark: support OF 1.3 OXMs

### DIFF
--- a/wireshark_gen/templates/_oftype_readers.lua
+++ b/wireshark_gen/templates/_oftype_readers.lua
@@ -68,8 +68,12 @@ function read_of_match_t(reader, version, subtree, field_name)
         dissect_of_match_v1_v1(reader, subtree:add("of_match"))
     elseif version == 2 then
         dissect_of_match_v2_v2(reader, subtree:add("of_match"))
-    elseif version >= 3 then
+    elseif version == 3 then
         dissect_of_match_v3_v3(reader, subtree:add("of_match"))
+    elseif version == 4 then
+        dissect_of_match_v3_v4(reader, subtree:add("of_match"))
+    else
+        error("Unsupported match version")
     end
 end
 


### PR DESCRIPTION
Reviewer: trivial

Need to call the OF 1.4 match dissector instead of the 1.3 dissector.
