### PR TITLE
java_model: generate OFErrorMsg accessor for ErrorCause data

### DIFF
--- a/java_gen/java_model.py
+++ b/java_gen/java_model.py
@@ -587,6 +587,8 @@ class JavaOFInterface(object):
             if not find(lambda x: x.name == "mask", self.ir_model_members):
                 virtual_members.append(
                         JavaVirtualMember(self, "mask", find(lambda x: x.name == "value", self.ir_model_members).java_type))
+        elif self.name =="OFErrorMsg":
+            virtual_members += [ JavaVirtualMember(self, "data", java_type.error_cause_data) ]
 
         if not find(lambda m: m.name == "version", self.ir_model_members):
             virtual_members.append(JavaVirtualMember(self, "version", java_type.of_version))


### PR DESCRIPTION
Reviewer: @Sovietaced @vishnu-emmadi @rlane
in the loxigen model, the virtual of_error_msg superclass does not have
a data field) (but all its concrete subclasses have one). This little
patch makes the java model generate a "data" contract in the interface
anyway, which is useful for error handling schemes that depend on the
type of the causing message.
