### PR TITLE
pyloxi: fix alignment inside unaligned structures

### DIFF
--- a/py_gen/templates/_unpack.py
+++ b/py_gen/templates/_unpack.py
@@ -35,7 +35,7 @@
 ::     elif type(m) == OFLengthMember:
         _${m.name} = ${gen_unpack_expr(m.oftype, 'reader', version=version)}
         orig_reader = reader
-        reader = orig_reader.slice(_${m.name} - (${m.offset} + ${m.length}))
+        reader = orig_reader.slice(_${m.name}, ${m.offset + m.length})
 ::     elif type(m) == OFFieldLengthMember:
 ::         field_length_members[m.field_name] = m
         _${m.name} = ${gen_unpack_expr(m.oftype, 'reader', version=version)}

--- a/py_gen/templates/generic_util.py
+++ b/py_gen/templates/generic_util.py
@@ -105,7 +105,7 @@ class OFReader(object):
         self.offset += length
 
     def skip_align(self):
-        new_offset = ((self.start + self.offset + 7) / 8 * 8) - self.start
+        new_offset = (self.offset + 7) / 8 * 8
         if new_offset > self.length:
             raise loxi.ProtocolError("Buffer too short")
         self.offset = new_offset
@@ -114,9 +114,10 @@ class OFReader(object):
         return self.offset == self.length
 
     # Used when parsing objects that have their own length fields
-    def slice(self, length):
-        if self.offset + length > self.length:
+    def slice(self, length, rewind=0):
+        if self.offset + length - rewind > self.length:
             raise loxi.ProtocolError("Buffer too short")
-        reader = OFReader(self.buf, self.start + self.offset, length)
-        self.offset += length
+        reader = OFReader(self.buf, self.start + self.offset - rewind, length)
+        reader.skip(rewind)
+        self.offset += length - rewind
         return reader

--- a/py_gen/tests/generic_util.py
+++ b/py_gen/tests/generic_util.py
@@ -102,17 +102,17 @@ class TestOFReader(unittest.TestCase):
         self.assertEquals(reader.is_empty(), True)
 
     def test_skip_align(self):
-        reader = OFReader("abcd" + "efgh" + "ijkl" + "mnop" + "qr")
+        reader = OFReader("abcd" + "efgh" + "ijkl" + "mnop" + "qrst")
         reader.skip_align()
         self.assertEquals(reader.peek('2s')[0], 'ab')
         self.assertEquals(reader.read('2s')[0], "ab")
         reader.skip_align()
         self.assertEquals(reader.peek('2s')[0], 'ij')
         self.assertEquals(reader.read('2s')[0], 'ij')
-        child = reader.slice(8)
-        self.assertEquals(child.peek('2s')[0], 'kl')
+        child = reader.slice(10)
+        self.assertEquals(child.read('2s')[0], 'kl')
         child.skip_align()
-        self.assertEquals(child.peek('2s')[0], 'qr')
+        self.assertEquals(child.peek('2s')[0], 'st')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Reviewer: @wilmo119

Alignment needs to be considered from the beginning of the object, not the 
beginning of the message.
