### PR TITLE
Another fix for OFGroup.java

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFGroup.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFGroup.java
@@ -38,7 +38,7 @@ public class OFGroup implements OFValueType<OFGroup> {
     public final static OFGroup ANY = new NamedGroup(ANY_VAL, "any");
 
     /** group 0 in case we need it */
-    public static final OFGroup ZERO = OFGroup.of(ZERO_VAL);
+    public static final OFGroup ZERO = new OFGroup(ZERO_VAL);
 
     public static final OFGroup NO_MASK = ANY;
     public static final OFGroup FULL_MASK = ZERO;


### PR DESCRIPTION
Reviewer: @rlane 

Well, that introduced another subtle bug. Using "new OFGroup(ZERO_VAL)" instead of "OFGroup.of(ZERO_VAL)" is the correct way to instantiate the ZERO object. It's null otherwise, which makes sense.