### PR TITLE
OFPortDesc: add convenience method to access BsnPortGenerationId

### DIFF
--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFPortDescTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFPortDescTest.java
@@ -1,19 +1,24 @@
 package org.projectfloodlight.protocol;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.HashSet;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFPortConfig;
 import org.projectfloodlight.openflow.protocol.OFPortDesc;
+import org.projectfloodlight.openflow.protocol.OFPortDescProp;
 import org.projectfloodlight.openflow.protocol.OFPortState;
 import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.types.U64;
 
-import static org.hamcrest.Matchers.is;
-
-import static org.junit.Assert.assertThat;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Tests auxiliary OFPortDesc methods for all versions of OpenFlow
@@ -50,4 +55,25 @@ public class OFPortDescTest {
                 .build();
         assertThat(desc.isEnabled(), is(false));
     }
+
+    @Test
+    public void testGenerationIdZeroIfUnset() {
+       for(OFVersion v: OFVersion.values()) {
+           OFFactory factory = OFFactories.getFactory(v);
+           assertThat("For version "+v, factory.buildPortDesc().build().getBsnGenerationId(),
+                    Matchers.equalTo(U64.ZERO));
+       }
+    }
+
+    @Test
+    public void testGenerationIdSet() {
+        OFFactory factory = OFFactories.getFactory(OFVersion.OF_14);
+        OFPortDesc desc = factory.buildPortDesc()
+          .setProperties(ImmutableList.<OFPortDescProp>of(
+                  factory.portDescPropBsnGenerationId(U64.of(1234))))
+          .build();
+
+       assertThat(desc.getBsnGenerationId(), equalTo(U64.of(1234)));
+    }
+
 }

--- a/java_gen/templates/_imports.java
+++ b/java_gen/templates/_imports.java
@@ -5,6 +5,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.projectfloodlight.openflow.protocol.*;
 import org.projectfloodlight.openflow.protocol.action.*;
 import org.projectfloodlight.openflow.protocol.actionid.*;

--- a/java_gen/templates/custom/OFPortDesc.java
+++ b/java_gen/templates/custom/OFPortDesc.java
@@ -8,4 +8,27 @@
     public boolean isEnabled() {
         return (!state.contains(OFPortState.LINK_DOWN) && !config.contains(OFPortConfig.PORT_DOWN));
     }
-    
+
+    /**
+     * Returns the current generation ID of this port.
+     *
+     * The generationId is reported by the switch as a @{link OFPortDescProp} in
+     * @link{OFPortDescStatsReply} and @link{OFPortStatus} messages. If the
+     * current OFPortDesc does not contain a generation Id, returns U64.ZERO;
+     *
+     * For OpenFlow versions earlier than 1.4, always returns U64.ZERO;
+     *
+     * @return the generation ID or U64.NULL if not reported
+     * @since 1.4
+     */
+     @Nonnull
+     public U64 getBsnGenerationId() {
+         //:: if msg.member_by_name("properties"):
+         for(OFPortDescProp prop: getProperties()) {
+            if(prop instanceof OFPortDescPropBsnGenerationId) {
+                return ((OFPortDescPropBsnGenerationId) prop).getGenerationId();
+            }
+         }
+         //:: #endif
+         return U64.ZERO;
+     }

--- a/java_gen/templates/custom/interface/OFPortDesc.java
+++ b/java_gen/templates/custom/interface/OFPortDesc.java
@@ -1,2 +1,23 @@
-    // Additional method
+    // Additional methods
+
+    /**
+     * Returns true if the port is up, i.e., it's neither administratively
+     * down nor link down. It currently does NOT take STP state into
+     * consideration
+     * @return whether the port is up
+     */
     boolean isEnabled();
+
+    /**
+     * Returns the current generation ID of this port.
+     *
+     * The generationId is reported by the switch as a @{link OFPortDescProp} in
+     * @link{OFPortDescStatsReply} and @link{OFPortStatus} messages. If the
+     * current OFPortDesc does not contain a generation Id, returns U64.ZERO;
+     *
+     * For OpenFlow versions earlier than 1.4, always returns U64.ZERO;
+     *
+     * @return the generation ID or U64.ZERO if not reported
+     * @since 1.4
+     */
+     public U64 getBsnGenerationId();


### PR DESCRIPTION
Reviewer: @rlane @Sovietaced 
CC: @sriniram 

This PR adds a convenience method to access the port generation id in the port desc.