### PR TITLE
openflow_input: add ipv6 TLV

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -546,3 +546,9 @@ struct of_bsn_tlv_negate : of_bsn_tlv {
     uint16_t type == 83;
     uint16_t length;
 };
+
+struct of_bsn_tlv_ipv6 : of_bsn_tlv {
+    uint16_t type == 84;
+    uint16_t length;
+    of_ipv6_t value; 
+};


### PR DESCRIPTION
Reviewer: @rlane 

Commit summary: ipv6 tlv is required to carry the switch management link local ip to be used by the sflow agent as agent ip.