### PR TITLE
LOXI-69: Ignore OF Objects with unknown discriminator values

### DIFF
--- a/java_gen/java_model.py
+++ b/java_gen/java_model.py
@@ -823,13 +823,26 @@ class JavaOFClass(object):
     @property
     @memoize
     def superclass(self):
-        return find(lambda c: c.version == self.version and c.c_name == self.ir_class.superclass, model.all_classes)
+        if self.ir_class.superclass:
+            superclass_name = self.ir_class.superclass.name
+            return find(lambda c: c.version == self.version and c.c_name == superclass_name, model.all_classes)
+        else:
+            return None
 
     @property
     @memoize
     def subclasses(self):
         return [ c for c in model.all_classes if c.version == self.version and c.ir_class.superclass
                    and c.ir_class.superclass.name == self.c_name ]
+    @property
+    @memoize
+    def ancestor_classes(self):
+        if self.superclass:
+            return [ self ] + self.superclass.ancestor_classes
+        else:
+            return [ self ]
+
+
 
 #######################################################################
 ### Member
@@ -1031,9 +1044,9 @@ class JavaVirtualMember(JavaMember):
     def value(self):
         return self._value
 
-    @property
-    def priv_value(self):
-        return self._value
+    #@property
+    #def priv_value(self):
+    #    return self._value
 
 
     @property

--- a/java_gen/java_type.py
+++ b/java_gen/java_type.py
@@ -263,7 +263,7 @@ def gen_list_jtype(java_base_name):
     # write op assumes class implements Writeable
     return JType("List<{}>".format(java_base_name)) \
         .op(
-            read= 'ChannelUtils.readList(bb, $length, {}Ver$version.READER)'.format(java_base_name), \
+            read= 'ChannelUtils.readList(context, bb, $length, {}Ver$version.READER)'.format(java_base_name), \
             write='ChannelUtils.writeList(bb, $name)',
             default="ImmutableList.<{}>of()".format(java_base_name),
             funnel='FunnelUtils.putList($name, sink)'
@@ -284,7 +284,7 @@ u8 =  JType('short', 'byte') \
         .op(read='U8.f(bb.readByte())', write='bb.writeByte(U8.t($name))', pub_type=True) \
         .op(read='bb.readByte()', write='bb.writeByte($name)', pub_type=False)
 u8_list =  JType('List<U8>') \
-        .op(read='ChannelUtils.readList(bb, $length, U8.READER)',
+        .op(read='ChannelUtils.readList(context, bb, $length, U8.READER)',
             write='ChannelUtils.writeList(bb, $name)',
             default='ImmutableList.<U8>of()',
             funnel='FunnelUtils.putList($name, sink)'
@@ -302,13 +302,13 @@ u32 = JType('long', 'int') \
         .op(read='bb.readInt()', write='bb.writeInt($name)', pub_type=False)
 u32_list = JType('List<U32>', 'int[]') \
         .op(
-                read='ChannelUtils.readList(bb, $length, U32.READER)',
+                read='ChannelUtils.readList(context, bb, $length, U32.READER)',
                 write='ChannelUtils.writeList(bb, $name)',
                 default="ImmutableList.<U32>of()",
                 funnel="FunnelUtils.putList($name, sink)")
 u64_list = JType('List<U64>', 'int[]') \
         .op(
-                read='ChannelUtils.readList(bb, $length, U64.READER)',
+                read='ChannelUtils.readList(context, bb, $length, U64.READER)',
                 write='ChannelUtils.writeList(bb, $name)',
                 default="ImmutableList.<U64>of()",
                 funnel="FunnelUtils.putList($name, sink)")
@@ -346,11 +346,11 @@ octets = JType('byte[]')\
             funnel="sink.putBytes($name)"
             );
 of_match = JType('Match') \
-        .op(read='ChannelUtilsVer$version.readOFMatch(bb)', \
+        .op(read='ChannelUtilsVer$version.readOFMatch(context, bb)', \
             write='$name.writeTo(bb)',
             default="OFFactoryVer$version.MATCH_WILDCARD_ALL");
 of_stat = JType('Stat') \
-         .op(read='ChannelUtilsVer$version.readOFStat(bb)', write='$name.writeTo(bb)')
+         .op(read='ChannelUtilsVer$version.readOFStat(context, bb)', write='$name.writeTo(bb)')
 of_time = JType('OFTime') \
          .op(read='OFTimeVer$version.READER.readFrom(bb)', \
              write='$name.writeTo(bb)')
@@ -383,7 +383,7 @@ ipv4 = JType("IPv4Address") \
             write="$name.write4Bytes(bb)",
             default='IPv4Address.NONE')
 ipv4_list =  JType('List<IPv4Address>') \
-        .op(read='ChannelUtils.readList(bb, $length, IPv4Address.READER)',
+        .op(read='ChannelUtils.readList(context, bb, $length, IPv4Address.READER)',
             write='ChannelUtils.writeList(bb, $name)',
             default='ImmutableList.<IPv4Address>of()',
             funnel="FunnelUtils.putList($name, sink)")
@@ -392,7 +392,7 @@ ipv6 = JType("IPv6Address") \
             write="$name.write16Bytes(bb)",
             default='IPv6Address.NONE')
 ipv6_list =  JType('List<IPv46ddress>') \
-        .op(read='ChannelUtils.readList(bb, $length, IPv6Address.READER)',
+        .op(read='ChannelUtils.readList(context, bb, $length, IPv6Address.READER)',
             write='ChannelUtils.writeList(bb, $name)',
             default='ImmutableList.<IPv6Address>of()',
             funnel="FunnelUtils.putList($name, sink)")
@@ -455,7 +455,7 @@ oxm = JType("OFOxm<?>")\
               write="$name.writeTo(bb)")
 oxm_list = JType("OFOxmList") \
         .op(
-            read= 'OFOxmList.readFrom(bb, $length, OFOxmVer$version.READER)', \
+            read= 'OFOxmList.readFrom(context, bb, $length, OFOxmVer$version.READER)', \
             write='$name.writeTo(bb)',
             default="OFOxmList.EMPTY")
 connection_uri = JType("OFConnectionIndex") \
@@ -466,7 +466,7 @@ oxs = JType("OFOxs<?>")\
         .op(read="OFOxsVer15.READER.readFrom(bb)",
             write="$name.writeTo(bb)")
 oxs_list = JType("OFOxsList") \
-        .op(read= 'OFOxsList.readFrom(bb, $length, OFOxsVer15.READER)', \
+        .op(read= 'OFOxsList.readFrom(context, bb, $length, OFOxsVer15.READER)', \
             write='$name.writeTo(bb)',
             default="OFOxsList.EMPTY")
 meter_features = JType("OFMeterFeatures")\
@@ -563,7 +563,7 @@ bundle_id = JType("BundleId") \
 udf = JType("UDF") \
          .op(version=ANY, read="UDF.read4Bytes(bb)", write="$name.write4Bytes(bb)", default="UDF.ZERO")
 error_cause_data = JType("OFErrorCauseData") \
-         .op(version=ANY, read="OFErrorCauseData.read(bb, $length, OFVersion.OF_$version)", write="$name.writeTo(bb)", default="OFErrorCauseData.NONE");
+         .op(version=ANY, read="OFErrorCauseData.read(context, bb, $length, OFVersion.OF_$version)", write="$name.writeTo(bb)", default="OFErrorCauseData.NONE");
 
 var_string = JType('String').op(
               read='ChannelUtils.readFixedLengthString(bb, $length)',

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/handler/UnparsedHandler.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/handler/UnparsedHandler.java
@@ -1,0 +1,25 @@
+package org.projectfloodlight.openflow.handler;
+
+import org.projectfloodlight.openflow.exceptions.OFParseError;
+import org.projectfloodlight.openflow.protocol.OFMessageReader;
+
+/**
+ * Contract for handlers that deal with unparsed messages.
+ *
+ * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+ */
+public interface UnparsedHandler {
+    /**
+     * Unknown message encountered
+     *
+     * invoked when an {@link OFMessageReader} encounters a discriminator value that it does
+     * not recognize, e.g., an OFMessage with an unknown type, or a TLV with an unknown TLV.
+     *
+     * @param parentClass the virtual class that the reader was trying to discriminate, e.g., OFMessage
+     * @param discriminatorName the name of the discriminator field, e.g., "type"
+     * @param value the unknown value.
+     *
+     * @throws OFParseError if the handler decides to abort the parsing of this message.
+     */
+    public void unparsedMessage(Class<?> parentClass, String discriminatorName, Object value) throws OFParseError;
+}

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/handler/UnparsedHandlers.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/handler/UnparsedHandlers.java
@@ -1,0 +1,112 @@
+package org.projectfloodlight.openflow.handler;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.projectfloodlight.openflow.exceptions.OFParseError;
+import org.slf4j.Logger;
+
+public class UnparsedHandlers {
+    private volatile static UnparsedHandler defaultHandler = throwOnUnparsed();
+
+    public static UnparsedHandler throwOnUnparsed() {
+        return ThrowOnUnparsedHandler.INSTANCE;
+    }
+
+    public static UnparsedHandler log(Logger logger) {
+        return new LogUnparsedHandler(logger);
+    }
+
+    public static void setDefaultHandler(UnparsedHandler handler) {
+        UnparsedHandlers.defaultHandler = handler;
+    }
+
+    public static UnparsedHandler getDefaultHandler() {
+        return defaultHandler;
+    }
+
+
+    /** UnparsedHandler that keeps count of the unknown messages by class and discrimantor.
+     *
+     *  Also emits a warn-level for the first such message encountered of each class and
+     *  discriminator value.
+     *
+     * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+     */
+    static class LogUnparsedHandler implements UnparsedHandler {
+        private final ConcurrentMap<String, ConcurrentMap<Object, AtomicInteger>> classnameDescriminatorCount =
+                new ConcurrentHashMap<>();
+
+        private final Logger logger;
+
+        public LogUnparsedHandler(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public void unparsedMessage(Class<?> parentClass, String discriminatorName,
+                Object value) throws OFParseError {
+            AtomicInteger count = getCountInteger(parentClass, value);
+
+            if(count.getAndIncrement() == 0) {
+                logger.warn("Unknown value for discriminator {} of class {}: {}. Message ignored.",
+                    discriminatorName, parentClass.getSimpleName(), value);
+            } else {
+                logger.debug("Unknown value for discriminator {} of class {}: {}. Message ignored.",
+                        discriminatorName, parentClass.getSimpleName(), value);
+            }
+        }
+
+        private AtomicInteger getCountInteger(Class<?> msgClass, Object discriminator) {
+            ConcurrentMap<Object, AtomicInteger> mapForClass = getMapForClass(msgClass);
+            final AtomicInteger count = mapForClass.get(discriminator);
+            if(count == null) {
+                final AtomicInteger newCount = new AtomicInteger(0);
+                final AtomicInteger presentCount = mapForClass.put(discriminator, newCount);
+                return presentCount != null ? presentCount : newCount;
+            } else {
+                return count;
+            }
+        }
+
+        private ConcurrentMap<Object, AtomicInteger> getMapForClass(Class<?> msgClass) {
+            String name = msgClass.getName();
+
+            final ConcurrentMap<Object, AtomicInteger> map = classnameDescriminatorCount.get(name);
+            if(map == null) {
+                final ConcurrentMap<Object, AtomicInteger> newMap = new ConcurrentHashMap<>();
+                final ConcurrentMap<Object, AtomicInteger> presentMap =
+                        classnameDescriminatorCount.putIfAbsent(name, newMap);
+                return presentMap != null ? presentMap : newMap;
+            } else {
+                return map;
+            }
+        }
+    }
+
+
+    /** UnparsedHandler that throws an exception.
+     */
+    static class ThrowOnUnparsedHandler implements UnparsedHandler {
+        private final static ThrowOnUnparsedHandler INSTANCE = new ThrowOnUnparsedHandler();
+
+        @Override
+        public void unparsedMessage(Class<?> parentClass, String discriminatorName,
+                Object value) throws OFParseError {
+            String msg = String.format("Unknown value for discriminator %s of class %s: %s",
+                    discriminatorName, parentClass.getSimpleName(), value);
+
+            throw new OFParseError(msg);
+        }
+    }
+
+
+    public static void handleUnparsed(Class<?> msgClass, String discriminatorName, byte value) throws OFParseError {
+        getDefaultHandler().unparsedMessage(msgClass, discriminatorName, Byte.valueOf(value));
+    }
+
+    public static void handleUnparsed(Class<?> msgClass, String discriminatorName, int value) throws OFParseError {
+        getDefaultHandler().unparsedMessage(msgClass, discriminatorName, Integer.valueOf(value));
+    }
+}

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/AbstractOFMessageReader.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/AbstractOFMessageReader.java
@@ -1,0 +1,14 @@
+package org.projectfloodlight.openflow.protocol;
+
+import org.projectfloodlight.openflow.exceptions.OFParseError;
+
+import io.netty.buffer.ByteBuf;
+
+public abstract class AbstractOFMessageReader<T> implements OFMessageReader<T> {
+
+    @Override
+    public final T readFrom(ByteBuf bb) throws OFParseError {
+        return readFrom(OFMessageReaderContexts.DEFAULT, bb);
+    }
+
+}

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageReader.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageReader.java
@@ -1,8 +1,44 @@
 package org.projectfloodlight.openflow.protocol;
 
-import io.netty.buffer.ByteBuf;
+import javax.annotation.Nullable;
+
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Generic OpenFlow object reader.
+ *
+ * Contract for Readers that parse a certain object type out of a {@link ByteBuf}.
+ *
+ * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+ * @param <T> - the type of the object to be read.
+ */
 public interface OFMessageReader<T> {
+    /**
+     * Read a message from the ByteBuf, with specified context.
+     *
+     * @param context - provides context to the read operation. will be passed on
+     *    to delegate reader.
+     * @param bb the byte buffer to read from
+     * @return the read message. null if no full message is available in the buffer.
+     * @throws OFParseError if the message in the buffer could not be parsed. No assumptions
+     *   should be made on the state of the buffer in this case.
+     */
+    @Nullable
+    T readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError;
+
+    /**
+     * Read a message from a ByteBuf, with default context.
+     *
+     * Convenience method for clients who do not want to specify a context.
+     *
+     * Delegates to readFrom(OFMessageReaderContexts.DEFAULT, bb);
+     * @param bb the byte buffer to read from
+     * @return the parsed message, or null if no full message is available in the buffer.
+     * @throws OFParseError if the message in the buffer could not be parsed. No assumptions
+     *   should be made on the state of the buffer after a parse error.
+     */
+    @Nullable
     T readFrom(ByteBuf bb) throws OFParseError;
 }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageReaderContext.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageReaderContext.java
@@ -1,0 +1,29 @@
+package org.projectfloodlight.openflow.protocol;
+
+import org.projectfloodlight.openflow.handler.UnparsedHandler;
+
+/**
+ * Context for a {@link OFMessageReader} read operation.
+ *
+ * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+ */
+public class OFMessageReaderContext {
+    private final UnparsedHandler unparsedHandler;
+
+    private OFMessageReaderContext(UnparsedHandler unparsedHandler) {
+        this.unparsedHandler = unparsedHandler;
+    }
+
+    /**
+     * Retrieve the {@link UnparsedHandler}
+     *
+     * @return the {@link UnparsedHandler} to be invoked if a message on the wire is unknown.
+     */
+    public UnparsedHandler getUnparsedHandler() {
+        return unparsedHandler;
+    }
+
+    public static OFMessageReaderContext of(UnparsedHandler unparsedHandler) {
+        return new OFMessageReaderContext(unparsedHandler);
+    }
+}

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageReaderContexts.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageReaderContexts.java
@@ -1,0 +1,10 @@
+package org.projectfloodlight.openflow.protocol;
+
+import org.projectfloodlight.openflow.handler.UnparsedHandlers;
+
+public class OFMessageReaderContexts {
+
+    public static final OFMessageReaderContext DEFAULT =
+            OFMessageReaderContext.of(UnparsedHandlers.getDefaultHandler());
+
+}

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFOxmList.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFOxmList.java
@@ -4,7 +4,6 @@ import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.protocol.match.MatchFields;
@@ -18,6 +17,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkable {
     private static final Logger logger = LoggerFactory.getLogger(OFOxmList.class);
@@ -97,9 +98,9 @@ public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkab
         return new OFOxmList(map);
     }
 
-    public static OFOxmList readFrom(ByteBuf bb, int length,
+    public static OFOxmList readFrom(OFMessageReaderContext context, ByteBuf bb, int length,
             OFMessageReader<OFOxm<?>> reader) throws OFParseError {
-        return ofList(ChannelUtils.readList(bb, length, reader));
+        return ofList(ChannelUtils.readList(context, bb, length, reader));
     }
 
     @Override

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFOxsList.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFOxsList.java
@@ -40,7 +40,7 @@ public class OFOxsList implements Iterable<OFOxs<?>>, Writeable, PrimitiveSinkab
         private final Map<StatFields, OFOxs<?>> oxsMap;
 
         public Builder() {
-            oxsMap = new EnumMap<StatFields, OFOxs<?>>(StatFields.class);
+            oxsMap = new EnumMap<>(StatFields.class);
         }
 
         public Builder(EnumMap<StatFields, OFOxs<?>> oxsMap) {
@@ -66,7 +66,7 @@ public class OFOxsList implements Iterable<OFOxs<?>>, Writeable, PrimitiveSinkab
     }
 
     public static OFOxsList ofList(Iterable<OFOxs<?>> oxsList) {
-        Map<StatFields, OFOxs<?>> map = new EnumMap<StatFields, OFOxs<?>>(
+        Map<StatFields, OFOxs<?>> map = new EnumMap<>(
                 StatFields.class);
         for (OFOxs<?> o : oxsList) {
             map.put(o.getStatField().id, o);
@@ -75,7 +75,7 @@ public class OFOxsList implements Iterable<OFOxs<?>>, Writeable, PrimitiveSinkab
     }
 
     public static OFOxsList of(OFOxs<?>... oxss) {
-        Map<StatFields, OFOxs<?>> map = new EnumMap<StatFields, OFOxs<?>>(
+        Map<StatFields, OFOxs<?>> map = new EnumMap<>(
                 StatFields.class);
         for (OFOxs<?> o : oxss) {
             map.put(o.getStatField().id, o);
@@ -83,9 +83,9 @@ public class OFOxsList implements Iterable<OFOxs<?>>, Writeable, PrimitiveSinkab
         return new OFOxsList(map);
     }
 
-    public static OFOxsList readFrom(ByteBuf bb, int length,
+    public static OFOxsList readFrom(OFMessageReaderContext context, ByteBuf bb, int length,
             OFMessageReader<OFOxs<?>> reader) throws OFParseError {
-        return ofList(ChannelUtils.readList(bb, length, reader));
+        return ofList(ChannelUtils.readList(context, bb, length, reader));
     }
 
     @Override
@@ -96,7 +96,7 @@ public class OFOxsList implements Iterable<OFOxs<?>>, Writeable, PrimitiveSinkab
     }
 
     public OFOxsList.Builder createBuilder() {
-        return new OFOxsList.Builder(new EnumMap<StatFields, OFOxs<?>>(oxsMap));
+        return new OFOxsList.Builder(new EnumMap<>(oxsMap));
     }
 
     @Override

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver10/ChannelUtilsVer10.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver10/ChannelUtilsVer10.java
@@ -3,13 +3,15 @@ package org.projectfloodlight.openflow.protocol.ver10;
 import java.util.EnumSet;
 import java.util.Set;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFActionType;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled
@@ -18,8 +20,8 @@ import com.google.common.hash.PrimitiveSink;
  */
 
 public class ChannelUtilsVer10 {
-    public static Match readOFMatch(final ByteBuf bb) throws OFParseError {
-        return OFMatchV1Ver10.READER.readFrom(bb);
+    public static Match readOFMatch(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFMatchV1Ver10.READER.readFrom(context, bb);
     }
 
     public static Set<OFActionType> readSupportedActions(ByteBuf bb) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver11/ChannelUtilsVer11.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver11/ChannelUtilsVer11.java
@@ -1,10 +1,12 @@
 package org.projectfloodlight.openflow.protocol.ver11;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled
@@ -13,8 +15,8 @@ import org.projectfloodlight.openflow.protocol.stat.Stat;
  */
 
 public class ChannelUtilsVer11 {
-    public static Match readOFMatch(final ByteBuf bb) throws OFParseError {
-        return OFMatchV2Ver11.READER.readFrom(bb);
+    public static Match readOFMatch(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFMatchV2Ver11.READER.readFrom(context, bb);
     }
 
     public static OFMatchBmap readOFMatchBmap(ByteBuf bb) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver12/ChannelUtilsVer12.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver12/ChannelUtilsVer12.java
@@ -1,12 +1,13 @@
 package org.projectfloodlight.openflow.protocol.ver12;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMatchBmap;
-import org.projectfloodlight.openflow.protocol.match.Match;
-import org.projectfloodlight.openflow.protocol.ver12.OFMatchV3Ver12;
 import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
+import org.projectfloodlight.openflow.protocol.OFMatchBmap;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
+import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled
@@ -15,8 +16,8 @@ import org.projectfloodlight.openflow.protocol.stat.Stat;
  */
 
 public class ChannelUtilsVer12 {
-    public static Match readOFMatch(final ByteBuf bb) throws OFParseError {
-        return OFMatchV3Ver12.READER.readFrom(bb);
+    public static Match readOFMatch(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFMatchV3Ver12.READER.readFrom(context, bb);
     }
 
     // TODO these need to be figured out / removed

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver13/ChannelUtilsVer13.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver13/ChannelUtilsVer13.java
@@ -1,10 +1,12 @@
 package org.projectfloodlight.openflow.protocol.ver13;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled
@@ -13,8 +15,8 @@ import org.projectfloodlight.openflow.protocol.stat.Stat;
  */
 
 public class ChannelUtilsVer13 {
-    public static Match readOFMatch(final ByteBuf bb) throws OFParseError {
-        return OFMatchV3Ver13.READER.readFrom(bb);
+    public static Match readOFMatch(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFMatchV3Ver13.READER.readFrom(context, bb);
     }
 
     public static OFMatchBmap readOFMatchBmap(ByteBuf bb) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver14/ChannelUtilsVer14.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver14/ChannelUtilsVer14.java
@@ -1,10 +1,12 @@
 package org.projectfloodlight.openflow.protocol.ver14;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into ByteBufs
@@ -13,8 +15,8 @@ import org.projectfloodlight.openflow.protocol.stat.Stat;
  */
 
 public class ChannelUtilsVer14 {
-    public static Match readOFMatch(final ByteBuf bb) throws OFParseError {
-        return OFMatchV3Ver14.READER.readFrom(bb);
+    public static Match readOFMatch(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFMatchV3Ver14.READER.readFrom(context, bb);
     }
 
     public static OFMatchBmap readOFMatchBmap(ByteBuf bb) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver15/ChannelUtilsVer15.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver15/ChannelUtilsVer15.java
@@ -1,10 +1,12 @@
 package org.projectfloodlight.openflow.protocol.ver15;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 /**
  * Collection of helper functions for reading and writing into ByteBufs
  *
@@ -12,12 +14,12 @@ import org.projectfloodlight.openflow.protocol.stat.Stat;
  */
 
 public class ChannelUtilsVer15 {
-    public static Match readOFMatch(final ByteBuf bb) throws OFParseError {
-        return OFMatchV3Ver15.READER.readFrom(bb);
+    public static Match readOFMatch(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFMatchV3Ver15.READER.readFrom(context, bb);
     }
 
-    public static Stat readOFStat(final ByteBuf bb) throws OFParseError {
-        return OFStatV6Ver15.READER.readFrom(bb);
+    public static Stat readOFStat(final OFMessageReaderContext context, final ByteBuf bb) throws OFParseError {
+        return OFStatV6Ver15.READER.readFrom(context, bb);
     }
 
     public static OFMatchBmap readOFMatchBmap(ByteBuf bb) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
@@ -1,7 +1,5 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.Inet4Address;
@@ -12,12 +10,15 @@ import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Wrapper around an IPv4Address address
@@ -45,9 +46,9 @@ public class IPv4Address extends IPAddress<IPv4Address> implements Writeable {
 
     public final static Reader READER = new Reader();
 
-    private static class Reader implements OFMessageReader<IPv4Address> {
+    private static class Reader extends AbstractOFMessageReader<IPv4Address> {
         @Override
-        public IPv4Address readFrom(ByteBuf bb) throws OFParseError {
+        public IPv4Address readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return new IPv4Address(bb.readInt());
         }
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
@@ -1,7 +1,5 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -14,12 +12,15 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedLongs;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * IPv6 address object. Instance controlled, immutable. Internal representation:
@@ -52,9 +53,9 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
 
     public final static Reader READER = new Reader();
 
-    private static class Reader implements OFMessageReader<IPv6Address> {
+    private static class Reader extends AbstractOFMessageReader<IPv6Address> {
         @Override
-        public IPv6Address readFrom(ByteBuf bb) throws OFParseError {
+        public IPv6Address readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return new IPv6Address(bb.readLong(), bb.readLong());
         }
     }
@@ -561,8 +562,8 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
             throw new IllegalArgumentException("16 bit word index must be in [0,7]");
     }
 
-    /** 
-     * get the index of the first word where to apply IPv6 zero compression 
+    /**
+     * get the index of the first word where to apply IPv6 zero compression
      *
      * @return the index
      */

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBooleanValue.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBooleanValue.java
@@ -17,12 +17,14 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFBooleanValue implements Writeable, OFValueType<OFBooleanValue> {
     public final static OFBooleanValue TRUE = new OFBooleanValue(true);
@@ -83,9 +85,9 @@ public class OFBooleanValue implements Writeable, OFValueType<OFBooleanValue> {
         bb.writeByte(getInt());
     }
 
-    private static class Reader implements OFMessageReader<OFBooleanValue> {
+    private static class Reader extends AbstractOFMessageReader<OFBooleanValue> {
         @Override
-        public OFBooleanValue readFrom(ByteBuf bb) throws OFParseError {
+        public OFBooleanValue readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return of(bb.readByte() != 0);
         }
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
@@ -17,13 +17,15 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Ints;
+
+import io.netty.buffer.ByteBuf;
 
 public class U16 implements Writeable, OFValueType<U16> {
     private final static short ZERO_VAL = 0;
@@ -101,9 +103,9 @@ public class U16 implements Writeable, OFValueType<U16> {
 
     public final static Reader READER = new Reader();
 
-    private static class Reader implements OFMessageReader<U16> {
+    private static class Reader extends AbstractOFMessageReader<U16> {
         @Override
-        public U16 readFrom(ByteBuf bb) throws OFParseError {
+        public U16 readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return ofRaw(bb.readShort());
         }
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U32.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U32.java
@@ -17,13 +17,15 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 public class U32 implements Writeable, OFValueType<U32> {
     private final static int ZERO_VAL = 0;
@@ -102,9 +104,9 @@ public class U32 implements Writeable, OFValueType<U32> {
 
     public final static Reader READER = new Reader();
 
-    private static class Reader implements OFMessageReader<U32> {
+    private static class Reader extends AbstractOFMessageReader<U32> {
         @Override
-        public U32 readFrom(ByteBuf bb) throws OFParseError {
+        public U32 readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return new U32(bb.readInt());
         }
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U64.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U64.java
@@ -19,13 +19,15 @@ package org.projectfloodlight.openflow.types;
 
 import java.math.BigInteger;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedLongs;
+
+import io.netty.buffer.ByteBuf;
 
 public class U64 implements Writeable, OFValueType<U64>, HashValue<U64> {
     private static final long UNSIGNED_MASK = 0x7fffffffffffffffL;
@@ -172,9 +174,9 @@ public class U64 implements Writeable, OFValueType<U64>, HashValue<U64> {
 
     public final static Reader READER = new Reader();
 
-    private static class Reader implements OFMessageReader<U64> {
+    private static class Reader extends AbstractOFMessageReader<U64> {
         @Override
-        public U64 readFrom(ByteBuf bb) throws OFParseError {
+        public U64 readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return U64.ofRaw(bb.readLong());
         }
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U8.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U8.java
@@ -17,13 +17,15 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
-import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.AbstractOFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedBytes;
+
+import io.netty.buffer.ByteBuf;
 
 public class U8 implements Writeable, OFValueType<U8> {
     private final static byte ZERO_VAL = 0;
@@ -104,9 +106,9 @@ public class U8 implements Writeable, OFValueType<U8> {
 
     public final static Reader READER = new Reader();
 
-    private static class Reader implements OFMessageReader<U8> {
+    private static class Reader extends AbstractOFMessageReader<U8> {
         @Override
-        public U8 readFrom(ByteBuf bb) throws OFParseError {
+        public U8 readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             return new U8(bb.readByte());
         }
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/ChannelUtils.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/ChannelUtils.java
@@ -2,9 +2,9 @@ package org.projectfloodlight.openflow.util;
 
 import java.util.List;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
 import org.projectfloodlight.openflow.protocol.Writeable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled
@@ -57,13 +59,13 @@ public class ChannelUtils {
         bb.writeBytes(byteArray);
     }
 
-    public static <T> List<T> readList(ByteBuf bb, int length, OFMessageReader<T> reader) throws OFParseError {
+    public static <T> List<T> readList(OFMessageReaderContext context, ByteBuf bb, int length, OFMessageReader<T> reader) throws OFParseError {
         int end = bb.readerIndex() + length;
         Builder<T> builder = ImmutableList.<T>builder();
         if(logger.isTraceEnabled())
             logger.trace("readList(length={}, reader={})", length, reader.getClass());
         while(bb.readerIndex() < end) {
-            T read = reader.readFrom(bb);
+            T read = reader.readFrom(context, bb);
             if(logger.isTraceEnabled())
                 logger.trace("readList: read={}, left={}", read, end - bb.readerIndex());
             builder.add(read);

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/protocol/ver13/OFMessageUnknownTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/protocol/ver13/OFMessageUnknownTest.java
@@ -1,0 +1,57 @@
+package org.projectfloodlight.openflow.protocol.ver13;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.projectfloodlight.openflow.exceptions.OFParseError;
+import org.projectfloodlight.openflow.handler.UnparsedHandlers;
+import org.projectfloodlight.openflow.protocol.OFEchoReply;
+import org.projectfloodlight.openflow.protocol.OFFactories;
+import org.projectfloodlight.openflow.protocol.OFMessage;
+import org.projectfloodlight.openflow.protocol.OFMessageReader;
+import org.projectfloodlight.openflow.protocol.OFMessageReaderContext;
+import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.protocol.oxm.OFOxm;
+import org.projectfloodlight.openflow.protocol.oxm.OFOxmInPhyPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+public class OFMessageUnknownTest {
+    private static final Logger logger =
+            LoggerFactory.getLogger(OFMessageUnknownTest.class);
+
+    final static byte[] UNKNOWN_MESSAGE_SERIALIZED =
+            new byte[] { 0x4, 077, 0x0, 0xb, 0x12, 0x34, 0x56, 0x78, 0x61, 0x62, 0x63 };
+
+    final static byte[] OXM_UNKNOWN_SERIALIZED =
+            new byte[] { (byte) 0x80, 0x0, /** tcp flags, introduced in OF1.5 */ 42 << 1, 0x2, 0x0, 0x0};
+
+    @Test
+    public void testSkipUnknownMessage() throws OFParseError {
+        OFMessageReaderContext context = OFMessageReaderContext.of(UnparsedHandlers.log(logger));
+        OFMessageReader<OFMessage> reader = OFFactories.getFactory(OFVersion.OF_13).getReader();
+        ByteBuf buffer = Unpooled.wrappedBuffer(UNKNOWN_MESSAGE_SERIALIZED, OFEchoReplyVer13Test.ECHO_REPLY_SERIALIZED);
+        OFMessage message = reader.readFrom(context, buffer);
+        assertThat(message, CoreMatchers.nullValue());
+        assertThat(buffer.readerIndex(), equalTo(UNKNOWN_MESSAGE_SERIALIZED.length));
+        OFMessage message2 = reader.readFrom(context, buffer);
+        assertThat(message2, CoreMatchers.instanceOf(OFEchoReply.class));
+    }
+
+    @Test
+    public void testSkipUnknownTlv() throws OFParseError {
+        OFMessageReaderContext context = OFMessageReaderContext.of(UnparsedHandlers.log(logger));
+        OFMessageReader<OFOxm<?>> reader = OFOxmVer13.READER;
+        ByteBuf buffer = Unpooled.wrappedBuffer(OXM_UNKNOWN_SERIALIZED, OFOxmInPhyPortVer13Test.OXM_IN_PHY_PORT_SERIALIZED);
+        OFOxm<?> message = reader.readFrom(context, buffer);
+        assertThat(message, CoreMatchers.nullValue());
+        assertThat(buffer.readerIndex(), equalTo(OXM_UNKNOWN_SERIALIZED.length));
+        OFOxm<?> message2 = reader.readFrom(context, buffer);
+        assertThat(message2, CoreMatchers.instanceOf(OFOxmInPhyPort.class));
+    }
+}

--- a/java_gen/templates/_imports.java
+++ b/java_gen/templates/_imports.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
+import org.projectfloodlight.openflow.handler.UnparsedHandlers;
 import org.projectfloodlight.openflow.protocol.*;
 import org.projectfloodlight.openflow.protocol.action.*;
 import org.projectfloodlight.openflow.protocol.actionid.*;

--- a/java_gen/templates/of_factories.java
+++ b/java_gen/templates/of_factories.java
@@ -49,8 +49,8 @@ public final class OFFactories {
             }
     }
 
-    private static class GenericReader implements OFMessageReader<OFMessage> {
-        public OFMessage readFrom(ByteBuf bb) throws OFParseError {
+    private static class GenericReader extends AbstractOFMessageReader<OFMessage> {
+        public OFMessage readFrom(OFMessageReaderContext context, ByteBuf bb) throws OFParseError {
             if(!bb.isReadable())
                 return null;
             short wireVersion = U8.f(bb.getByte(bb.readerIndex()));
@@ -64,7 +64,7 @@ public final class OFFactories {
             default:
                 throw new IllegalArgumentException("Unknown wire version: " + wireVersion);
             }
-            return factory.getReader().readFrom(bb);
+            return factory.getReader().readFrom(context, bb);
         }
     }
 


### PR DESCRIPTION
Reviewer: @Sovietaced @rlane 

This pull request enables us to ignore OF Messages that we do not understand (because we don't know the discriminator value). 

The previous behavior was to disconnect the switch if it sends a message we do not understand.

This PR solves the problem, but I really dislike how big and clunky and just ugly it is. I'm putting it up for discussion here. I'm not necessarily suggesting we merge it in the present form.
