### PR TITLE
Change toString() of OFMetadata

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFMetadata.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFMetadata.java
@@ -66,7 +66,7 @@ public class OFMetadata implements OFValueType<OFMetadata> {
 
     @Override
     public String toString() {
-        return "Metadata: " + u64.toString();
+        return u64.toString();
     }
 
     @Override


### PR DESCRIPTION
Reviewer: @rlane 

Change toString() of OFMetadata to not include the string 'Metadata:' before the value. No other type does this to my knowledge. We should probably remove it to be consistent with e.g. MacAddress, which is a hex string 'XX:XX:XX:XX:XX:XX', not 'MAC Address: XX:XX:XX:XX:XX:XX'.