### PR TITLE
Add gentable_add and gentable_delete error messages.

### DIFF
--- a/openflow_input/bsn-1.3
+++ b/openflow_input/bsn-1.3
@@ -36,3 +36,17 @@ struct of_instruction_bsn : of_instruction_experimenter {
     uint32_t subtype == ?;
     pad(4);
 };
+
+// BSN error messages
+struct of_bsn_error_header : of_experimenter_error_msg {
+    uint8_t version;
+    uint8_t type == 1;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t err_type == 0xffff;
+    uint16_t subtype == ?;
+    uint32_t experimenter == 0x5c16c7;
+    of_desc_str_t err_msg;
+    of_octets_t data;
+};
+

--- a/openflow_input/bsn_gentable
+++ b/openflow_input/bsn_gentable
@@ -362,3 +362,28 @@ struct of_action_bsn_gentable : of_action_bsn {
     uint32_t table_id;
     list(of_bsn_tlv_t) key;
 };
+
+// gentable error messages
+struct of_bsn_gentable_add_error : of_bsn_error_header {
+    uint8_t version;
+    uint8_t type == 1;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t err_type == 0xffff;
+    uint16_t subtype == 1;
+    uint32_t experimenter == 0x5c16c7;
+    of_desc_str_t err_msg;
+    of_octets_t data;
+};
+
+struct of_bsn_gentable_delete_error : of_bsn_error_header {
+    uint8_t version;
+    uint8_t type == 1;
+    uint16_t length;
+    uint32_t xid;
+    uint16_t err_type == 0xffff;
+    uint16_t subtype == 2;
+    uint32_t experimenter == 0x5c16c7;
+    of_desc_str_t err_msg;
+    of_octets_t data;
+};


### PR DESCRIPTION
Reviewer: @rlane 

I'm probably doing something stupid here, but can't figure out what the problem is.  Any help you can provide is appreciated.  Thanks.

'make all' dies generating pyloxi output:
```
AttributeError: 'NoneType' object has no attribute 'name'
Makefile:61: recipe for target '.loxi_ts.python' failed
make: *** [.loxi_ts.python] Error 1
```

'make check-all' dies in locitest:
```
test of_bsn_gentable_add_error_OF_VERSION_1_3_scalar:
TEST LOCI_ASSERT FAILURE object_id == OF_BSN_GENTABLE_ADD_ERROR :: src/test_scalar_acc.c:18317
\nASSERT 0. src/test_scalar_acc.c:18317\nMakefile:138: recipe for target 'check-c' failed
```
