### PR TITLE
java: generate setters for unwriteable fields LOXI-76

### DIFF
--- a/java_gen/templates/_field_accessors.java
+++ b/java_gen/templates/_field_accessors.java
@@ -28,7 +28,7 @@
     }
 //:: #endif
 
-//:: if generate_setters and prop.is_writeable:
+//:: if generate_setters:
     //:: setter_template_file_name = "%s/custom/%s_%s.java" % (template_dir, msg.name if not builder else msg.name + '.Builder', prop.setter_name)
     //:: if os.path.exists(setter_template_file_name):
     //:: include(setter_template_file_name, msg=msg, builder=builder, has_parent=has_parent)
@@ -36,12 +36,14 @@
     //:: else:
     @Override
     public ${msg.interface.name}.Builder ${prop.setter_name}(${prop.java_type.public_type} ${prop.name})${ "" if prop in msg.members else " throws UnsupportedOperationException"} {
-        //:: if prop in msg.members:
+        //:: if prop.is_writeable and prop in msg.members:
         this.${prop.name} = ${prop.name};
         this.${prop.name}Set = true;
         return this;
-        //:: else:
+        //:: elif prop.is_writeable:
             throw new UnsupportedOperationException("Property ${prop.name} not supported in version #{version}");
+        //:: else:
+            throw new UnsupportedOperationException("Property ${prop.name} is not writeable");
         //:: #endif
     }
     //:: #endif

--- a/java_gen/templates/of_interface.java
+++ b/java_gen/templates/of_interface.java
@@ -53,9 +53,7 @@ public interface ${msg.name}${ "<%s>" % msg.type_annotation if msg.type_annotati
         ${msg.name}${msg.type_variable} build();
 //:: for prop in msg.members:
         ${prop.java_type.public_type} ${prop.getter_name}()${ "" if prop.is_universal else " throws UnsupportedOperationException"};
-//:: if prop.is_writeable:
         Builder${msg.type_variable} ${prop.setter_name}(${prop.java_type.public_type} ${prop.name})${ "" if prop.is_universal else " throws UnsupportedOperationException"};
-//:: #endif
 //:: #endfor
     }
 }


### PR DESCRIPTION
Reviewer: @andi-bigswitch

https://github.com/floodlight/loxigen/pull/438 ran into a problem when we
tried to use a field as a discriminator when it was a normal data member in
the superclass. The java compiler complained that we hadn't provided an 
implementation of the setter in the concrete class.

This change fixes the problem by creating setters for unwriteable fields which 
throw an exception, like we do when the field isn't available in the OpenFlow 
version.

This obviously adds the setters in more places than necessary. We could 
possibly optimize this by checking each ancestor class to see if the field 
changed writeability and only emit a setter in that special case.