### PR TITLE
wireshark: rename to avoid conflict with upstream dissector

### DIFF
--- a/wireshark_gen/templates/openflow.lua
+++ b/wireshark_gen/templates/openflow.lua
@@ -39,7 +39,7 @@
 
 :: include('_ofreader.lua')
 
-p_of = Proto ("of", "OpenFlow")
+p_of = Proto ("of", "OpenFlow (LOXI)")
 ethernet_dissector = Dissector.get("eth")
 
 current_pkt = nil


### PR DESCRIPTION
Reviewer: trivial

Newer versions of Wireshark crash (!) because of the name conflict.