### PR TITLE
Match: consistently hide Fields w/ broken prereqs LOXI-75

### DIFF
--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/OFMatchPrerequisitesTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/OFMatchPrerequisitesTest.java
@@ -1,0 +1,86 @@
+package org.projectfloodlight.protocol.match;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.projectfloodlight.openflow.protocol.match.MatchField.ETH_TYPE;
+import static org.projectfloodlight.openflow.protocol.match.MatchField.IPV4_SRC;
+
+import java.util.Arrays;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.projectfloodlight.openflow.protocol.OFFactories;
+import org.projectfloodlight.openflow.protocol.OFFactory;
+import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.protocol.match.Match;
+import org.projectfloodlight.openflow.protocol.match.MatchField;
+import org.projectfloodlight.openflow.types.EthType;
+import org.projectfloodlight.openflow.types.IPv4Address;
+
+@RunWith(Parameterized.class)
+public class OFMatchPrerequisitesTest {
+    private final OFFactory factory;
+
+    @Parameters(name="{index}.ChannelHandlerVersion={0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {OFVersion.OF_10},
+                {OFVersion.OF_13},
+                {OFVersion.OF_14}
+        });
+    }
+
+    public OFMatchPrerequisitesTest(OFVersion version) {
+        factory = OFFactories.getFactory(version);
+    }
+
+    @Test
+    public void testPreRequisitesNotMet() {
+        Match match = factory.buildMatch()
+           .setExact(ETH_TYPE, EthType.IPv6)
+           .setExact(IPV4_SRC, IPv4Address.of("1.2.3.4"))
+           .build();
+
+        assertThat(match.get(ETH_TYPE), equalTo(EthType.IPv6));
+        assertThat(match.isExact(ETH_TYPE), equalTo(true));
+        assertThat(match.isPartiallyMasked(ETH_TYPE), equalTo(false));
+        assertThat(match.isFullyWildcarded(ETH_TYPE), equalTo(false));
+
+        assertThat(match.get(IPV4_SRC), nullValue());
+        assertThat(match.isExact(IPV4_SRC), equalTo(false));
+        assertThat(match.isPartiallyMasked(IPV4_SRC), equalTo(false));
+        assertThat(match.isFullyWildcarded(IPV4_SRC), equalTo(true));
+
+        Iterable<MatchField<?>> matchFields = match.getMatchFields();
+        assertThat(matchFields, Matchers.<MatchField<?>>iterableWithSize(1));
+        assertThat(matchFields, Matchers.<MatchField<?>>contains(MatchField.ETH_TYPE));
+    }
+
+    @Test
+    public void testPreRequisitesMet() {
+        Match match = factory.buildMatch()
+           .setExact(ETH_TYPE, EthType.IPv4)
+           .setExact(IPV4_SRC, IPv4Address.of("1.2.3.4"))
+           .build();
+
+        assertThat(match.get(ETH_TYPE), equalTo(EthType.IPv4));
+        assertThat(match.isExact(ETH_TYPE), equalTo(true));
+        assertThat(match.isPartiallyMasked(ETH_TYPE), equalTo(false));
+        assertThat(match.isFullyWildcarded(ETH_TYPE), equalTo(false));
+
+        assertThat(match.get(IPV4_SRC), equalTo(IPv4Address.of("1.2.3.4")));
+        assertThat(match.isExact(IPV4_SRC), equalTo(true));
+        assertThat(match.isPartiallyMasked(IPV4_SRC), equalTo(false));
+        assertThat(match.isFullyWildcarded(IPV4_SRC), equalTo(false));
+
+        Iterable<MatchField<?>> matchFields = match.getMatchFields();
+        assertThat(matchFields, Matchers.<MatchField<?>>iterableWithSize(2));
+        assertThat(matchFields, Matchers.<MatchField<?>>contains(MatchField.ETH_TYPE, MatchField.IPV4_SRC));
+    }
+
+
+}

--- a/java_gen/templates/custom/OFMatchV3.java
+++ b/java_gen/templates/custom/OFMatchV3.java
@@ -58,6 +58,9 @@
         if (!supports(field))
             throw new UnsupportedOperationException("${msg.name} does not support matching on field " + field.getName());
 
+        if(!field.arePrerequisitesOK(this))
+            return false;
+
         OFOxm<?> oxm = this.oxmList.get(field);
 
         return oxm != null && !oxm.isMasked();
@@ -67,6 +70,8 @@
     public boolean isFullyWildcarded(MatchField<?> field) {
         if (!supports(field))
             throw new UnsupportedOperationException("${msg.name} does not support matching on field " + field.getName());
+        if(!field.arePrerequisitesOK(this))
+            return true;
 
         OFOxm<?> oxm = this.oxmList.get(field);
 
@@ -77,6 +82,8 @@
     public boolean isPartiallyMasked(MatchField<?> field) {
         if (!supports(field))
             throw new UnsupportedOperationException("${msg.name} does not support matching on field " + field.getName());
+        if(!field.arePrerequisitesOK(this))
+            return false;
 
         OFOxm<?> oxm = this.oxmList.get(field);
 


### PR DESCRIPTION
Reviewer: @Sovietaced @wolverineav 

Previously, `isExact()`, `isPartiallyMasked()` and `isFullyWildcarded()`
did not check whether the required prerequisites for a field
had been set. get() and getMasked() did, leading to inconsistent
results / NPEs.

This makes all of the methods honor the prerequisite checks.
It also adds a unit test checking the behavior.