### PR TITLE
java: generate setters for unwriteable fields LOXI-76

### DIFF
--- a/java_gen/java_model.py
+++ b/java_gen/java_model.py
@@ -890,6 +890,16 @@ class JavaMember(object):
         else:
             return self.java_type.format_value(self.member.value, pub_type=False)
 
+    @property
+    def needs_setter(self):
+        if self.is_writeable:
+            return True
+        super_class = self.msg.super_class
+        if super_class:
+            super_member = super_class.member_by_name(self.name)
+            if super_member:
+                return super_member.needs_setter
+        return False
 
     @property
     def is_writeable(self):

--- a/java_gen/templates/_field_accessors.java
+++ b/java_gen/templates/_field_accessors.java
@@ -28,7 +28,7 @@
     }
 //:: #endif
 
-//:: if generate_setters:
+//:: if generate_setters and prop.needs_setter:
     //:: setter_template_file_name = "%s/custom/%s_%s.java" % (template_dir, msg.name if not builder else msg.name + '.Builder', prop.setter_name)
     //:: if os.path.exists(setter_template_file_name):
     //:: include(setter_template_file_name, msg=msg, builder=builder, has_parent=has_parent)

--- a/java_gen/templates/_field_accessors.java
+++ b/java_gen/templates/_field_accessors.java
@@ -28,7 +28,7 @@
     }
 //:: #endif
 
-//:: if generate_setters and prop.is_writeable:
+//:: if generate_setters:
     //:: setter_template_file_name = "%s/custom/%s_%s.java" % (template_dir, msg.name if not builder else msg.name + '.Builder', prop.setter_name)
     //:: if os.path.exists(setter_template_file_name):
     //:: include(setter_template_file_name, msg=msg, builder=builder, has_parent=has_parent)
@@ -36,12 +36,14 @@
     //:: else:
     @Override
     public ${msg.interface.name}.Builder ${prop.setter_name}(${prop.java_type.public_type} ${prop.name})${ "" if prop in msg.members else " throws UnsupportedOperationException"} {
-        //:: if prop in msg.members:
+        //:: if prop.is_writeable and prop in msg.members:
         this.${prop.name} = ${prop.name};
         this.${prop.name}Set = true;
         return this;
-        //:: else:
+        //:: elif prop.is_writeable:
             throw new UnsupportedOperationException("Property ${prop.name} not supported in version #{version}");
+        //:: else:
+            throw new UnsupportedOperationException("Property ${prop.name} is not writeable");
         //:: #endif
     }
     //:: #endif

--- a/java_gen/templates/of_interface.java
+++ b/java_gen/templates/of_interface.java
@@ -53,9 +53,7 @@ public interface ${msg.name}${ "<%s>" % msg.type_annotation if msg.type_annotati
         ${msg.name}${msg.type_variable} build();
 //:: for prop in msg.members:
         ${prop.java_type.public_type} ${prop.getter_name}()${ "" if prop.is_universal else " throws UnsupportedOperationException"};
-//:: if prop.is_writeable:
         Builder${msg.type_variable} ${prop.setter_name}(${prop.java_type.public_type} ${prop.name})${ "" if prop.is_universal else " throws UnsupportedOperationException"};
-//:: #endif
 //:: #endfor
     }
 }

--- a/java_gen/templates/of_interface.java
+++ b/java_gen/templates/of_interface.java
@@ -53,7 +53,9 @@ public interface ${msg.name}${ "<%s>" % msg.type_annotation if msg.type_annotati
         ${msg.name}${msg.type_variable} build();
 //:: for prop in msg.members:
         ${prop.java_type.public_type} ${prop.getter_name}()${ "" if prop.is_universal else " throws UnsupportedOperationException"};
+//:: if prop.needs_setter:
         Builder${msg.type_variable} ${prop.setter_name}(${prop.java_type.public_type} ${prop.name})${ "" if prop.is_universal else " throws UnsupportedOperationException"};
+//:: #endif
 //:: #endfor
     }
 }


### PR DESCRIPTION
Reviewer: @rlane
CC: @kenchiang 

This pull request replaces #439, which I am taking over from @rlane.

#438 ran into a problem when we tried to use a field as a discriminator when it was a normal data member in the superclass. The java compiler complained that we hadn't provided an 
implementation of the setter in the concrete class.

This PR improves on #439 in that the previous commit would add virtual Exception-raising setters
globally. This commit adds a method that specifically checks whether a setter is necessary.

A setter must be generated if the field is writeable in this class or any super class. Fields can turn non-writeable in a subclass if a superclass data member is used as a discriminator.
