### PR TITLE
Fix doc syntax, Java 8 does not like it

### DIFF
--- a/java_gen/templates/custom/OFPortDesc.java
+++ b/java_gen/templates/custom/OFPortDesc.java
@@ -13,7 +13,7 @@
      * Returns the current generation ID of this port.
      *
      * The generationId is reported by the switch as a @{link OFPortDescProp} in
-     * @link{OFPortDescStatsReply} and @link{OFPortStatus} messages. If the
+     * {@link OFPortDescStatsReply} and {@link OFPortStatus} messages. If the
      * current OFPortDesc does not contain a generation Id, returns U64.ZERO;
      *
      * For OpenFlow versions earlier than 1.4, always returns U64.ZERO;

--- a/java_gen/templates/custom/interface/OFPortDesc.java
+++ b/java_gen/templates/custom/interface/OFPortDesc.java
@@ -12,7 +12,7 @@
      * Returns the current generation ID of this port.
      *
      * The generationId is reported by the switch as a @{link OFPortDescProp} in
-     * @link{OFPortDescStatsReply} and @link{OFPortStatus} messages. If the
+     * {@link OFPortDescStatsReply} and {@link OFPortStatus} messages. If the
      * current OFPortDesc does not contain a generation Id, returns U64.ZERO;
      *
      * For OpenFlow versions earlier than 1.4, always returns U64.ZERO;


### PR DESCRIPTION
Reviewer: @rlane @andi-bigswitch 

Java 8 doesn't like doc syntax @link {...}, correct to {@link ...}. Java 7 appeared to accept syntax.