### PR TITLE
Upgrade Guava Version to 19.0

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>19.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Reviewer: @Sovietaced 
CC: @shudongz 

This PR upgrades the Guava dependency of openflowj to 19.0. The version was already upgraded in floodlight, which was causing problems.