### PR TITLE
Support bsn_l2_cache_hit tlv in 1.4.

### DIFF
--- a/openflow_input/bsn_l2_cache_hit
+++ b/openflow_input/bsn_l2_cache_hit
@@ -30,6 +30,7 @@
 
 #version 3
 #version 4
+#version 5
 
 /*
  * L2 Cache Hit


### PR DESCRIPTION
Reviewer: @rlane 