### PR TITLE
Make Bundle-Add inherit the XID of the nested message  #loxigen/454

### DIFF
--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFBundleAddTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFBundleAddTest.java
@@ -1,0 +1,74 @@
+package org.projectfloodlight.protocol;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.projectfloodlight.openflow.protocol.OFBundleAddMsg;
+import org.projectfloodlight.openflow.protocol.OFFactories;
+import org.projectfloodlight.openflow.protocol.OFFactory;
+import org.projectfloodlight.openflow.protocol.OFFlowAdd;
+import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.types.BundleId;
+
+/** Custom tests that validate that BundleAdd messages inherit the XID from their
+ *  contained message, as per OF Spec 1.4.0:
+ *  <p>
+ *  7.3.9.6 Adding messages to a bundle
+ *  <p>
+ *     Message added in a bundle should have a unique xid to help matching errors to messages,
+ *     and the xid of the bundle add message must be the same.
+ *  </p>
+ *
+ * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+ */
+public class OFBundleAddTest {
+    private final OFFactory factory = OFFactories.getFactory(OFVersion.OF_14);
+    private OFFlowAdd flowAdd;
+
+    @Before
+    public void setup() {
+        flowAdd = factory.buildFlowAdd().build();
+
+    }
+
+    @Test
+    public void testBundleAddBuilder() {
+        OFBundleAddMsg bundleAdd = createBundleAdd();
+        assertThat(bundleAdd.getXid(), equalTo(flowAdd.getXid()));
+    }
+
+    private OFBundleAddMsg createBundleAdd() {
+        return factory.buildBundleAddMsg()
+                .setBundleId(BundleId.of(1))
+                .setData(flowAdd)
+                .build();
+    }
+
+    @Test
+    public void testBundleAddBuilderWithParent() {
+        OFBundleAddMsg bundleAdd = createBundleAdd();
+
+        // validate BuilderWithParent
+        OFBundleAddMsg builtFromOtherMessage = bundleAdd.createBuilder()
+           .build();
+
+        assertThat(builtFromOtherMessage.getXid(), equalTo(builtFromOtherMessage.getData().getXid()));
+    }
+
+    @Test
+    public void testBundleAddBuilderWithParentOverwrite() {
+        OFFlowAdd flowAdd2 = factory.buildFlowAdd().setXid(1234L).build();
+
+        // BuilderWithParent, overwrite with new message
+        OFBundleAddMsg bundleAdd = createBundleAdd();
+
+        OFBundleAddMsg builtFromOtherMessage = bundleAdd.createBuilder()
+           .setData(flowAdd2)
+           .build();
+
+        assertThat(builtFromOtherMessage.getXid(), equalTo(flowAdd2.getXid()));
+    }
+
+}

--- a/java_gen/templates/custom/OFBundleAddMsg.Builder_setData.java
+++ b/java_gen/templates/custom/OFBundleAddMsg.Builder_setData.java
@@ -1,0 +1,15 @@
+    /** Custom setter that ensures the BundleAdd message inherits the XID from their
+     *  contained message, as per OF Spec 1.4.0:
+     *  <p>
+     *  7.3.9.6 Adding messages to a bundle
+     *  </p><p>
+     *     Message added in a bundle should have a unique xid to help matching errors to messages,
+     *     and the xid of the bundle add message must be the same.
+     *  </p>
+     */
+    @Override
+    public OFBundleAddMsg.Builder setData(OFMessage data) {
+        this.data = data;
+        this.dataSet = true;
+        return setXid(data.getXid());
+    }

--- a/java_gen/templates/custom/OFBundleAddMsgVer14.Builder_setData.java
+++ b/java_gen/templates/custom/OFBundleAddMsgVer14.Builder_setData.java
@@ -1,0 +1,1 @@
+//:: include("custom/OFBundleAddMsg.Builder_setData.java", msg=msg, version=version, has_parent=False)


### PR DESCRIPTION
Reviewer: @rlane 

This pull request addresses #454, by ensuring that Builders for BundleAdd set the BundleAdd XID to the XID of the nested message, as required by the OF Spec, 1.4, section 7.3.9.6 Adding messages to a bundle:

> Message added in a bundle should have a unique xid to help matching
> errors to messages, and the xid of the bundle add message must be the
> same.

Rich, do we foresee any switch-side work that would be necessary as a result of this?