### PR TITLE
Add of_queue_desc_prop_bsn and of_queue_desc_prop_bsn_queue_name

### DIFF
--- a/openflow_input/bsn_queue_name
+++ b/openflow_input/bsn_queue_name
@@ -1,4 +1,4 @@
-// Copyright 2015-2016, Big Switch Networks, Inc.
+// Copyright 2016, Big Switch Networks, Inc.
 //
 // LoxiGen is licensed under the Eclipse Public License, version 1.0 (EPL), with
 // the following special exception:
@@ -27,16 +27,10 @@
 
 #version 5
 
-struct of_port_desc_prop_bsn : of_port_desc_prop_experimenter {
+struct of_queue_desc_prop_bsn_queue_name : of_queue_desc_prop_bsn {
     uint16_t type == 0xffff;
     uint16_t length;
     uint32_t experimenter == 0x5c16c7;
-    uint32_t exp_type == ?;
-};
-
-struct of_queue_desc_prop_bsn : of_queue_desc_prop_experimenter {
-    uint16_t type == 0xffff;
-    uint16_t length;
-    uint32_t experimenter == 0x5c16c7;
-    uint32_t exp_type == ?;
+    uint32_t exp_type == 0;
+    of_str64_t name;
 };

--- a/openflow_input/bsn_queue_name
+++ b/openflow_input/bsn_queue_name
@@ -32,5 +32,5 @@ struct of_queue_desc_prop_bsn_queue_name : of_queue_desc_prop_bsn {
     uint16_t length;
     uint32_t experimenter == 0x5c16c7;
     uint32_t exp_type == 0;
-    of_str64_t name;
+    of_octets_t name; /* UTF-8 encoded. Not null terminated. */
 };

--- a/openflow_input/standard-1.4
+++ b/openflow_input/standard-1.4
@@ -2333,6 +2333,8 @@ struct of_queue_desc_stats_request : of_stats_request {
     uint16_t stats_type == 15;
     enum ofp_stats_request_flags flags;
     pad(4);
+    of_port_no_t port_no;
+    uint32_t queue_id;
 };
 
 struct of_queue_desc_prop {


### PR DESCRIPTION
Reviewer: @rlane 

This will allow use to return names associated with queues.
It also looks like of_queue_desc_stats_request was missing two fields.
