### PR TITLE
Dockerized build environment for loxigen

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
-dir=$(readlink -f $(dirname "$0"))
-docker run -it -v $dir:/loxi --rm floodlight/loxi-builder "$@"
+if [ -t 1 ]; then
+    tty_flag="-t"
+else
+    tty_flag=""
+fi
+dir=$(python -c 'import os; import sys; print os.path.abspath(sys.argv[1])' $(dirname "$0"))
+docker run -i $tty_flag --rm -v $dir:/loxi --rm floodlight/loxi-builder-ubuntu14 "$@"

--- a/docker.sh
+++ b/docker.sh
@@ -5,4 +5,4 @@ else
     tty_flag=""
 fi
 dir=$(python -c 'import os; import sys; print os.path.abspath(sys.argv[1])' $(dirname "$0"))
-docker run -i $tty_flag --rm -v $dir:/loxi --rm floodlight/loxi-builder-ubuntu14 "$@"
+docker run -i $tty_flag --rm -v $dir:/loxi floodlight/loxi-builder-ubuntu14 "$@"

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dir=$(readlink -f $(dirname "$0"))
+docker run -it -v $dir:/loxi --rm floodlight/loxi-builder "$@"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:14.04
+
+RUN apt-get update \
+  && apt-get upgrade -y --no-install-recommends build-essential python python-nose rsync openjdk-7-jdk maven
+
+RUN useradd -m -d /loxi -c 'loxi build user' -u 300 -s /bin/bash loxi
+COPY run-as-loxi /
+ENTRYPOINT [ "/run-as-loxi" ]

--- a/docker/run-as-loxi
+++ b/docker/run-as-loxi
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+loxi_uid=$(stat -c'%u' /loxi/loxigen.py)
+loxi_gid=$(stat -c'%g' /loxi/loxigen.py)
+usermod -u $loxi_uid -g $loxi_gid loxi || echo "ok"
+
+cd /loxi
+if [[ "$*" ]]; then
+    sudo -u loxi -i /bin/bash -c "$*"
+else
+    sudo -u loxi -i /bin/bash
+fi
+


### PR DESCRIPTION
Reviewer: @rlane 

This creates a dockerized build environment for loxigen. The environment is built automatically, daily and pushed to DockerHub as `floodlight/loxi-builder-ubuntu14`. 

Also adds a convenience start script that puts the user into the docker image, ready to start build (`./docker.sh`).