### PR TITLE
Expose MatchField prereqs

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -31,9 +31,8 @@ import org.projectfloodlight.openflow.types.VlanPcp;
 import org.projectfloodlight.openflow.types.VxlanNI;
 import org.projectfloodlight.openflow.types.VFI;
 
-import java.util.Collections;
 import java.util.Set;
-import java.util.HashSet;
+import com.google.common.collect.ImmutableSet;
 
 public class MatchField<F extends OFValueType<F>> {
     private final String name;
@@ -43,11 +42,10 @@ public class MatchField<F extends OFValueType<F>> {
     private MatchField(final String name, final MatchFields id, Prerequisite<?>... prerequisites) {
         this.name = name;
         this.id = id;
-        if (prerequisites == null || prerequisites.length == 0) {
-            this.prerequisites = Collections.emptySet();
-        } else {
-            this.prerequisites = new HashSet<Prerequisite<?>>();
-            Collections.addAll(this.prerequisites, prerequisites);
+        if (prerequisites == null) {
+            this.prerequisites = ImmutableSet.<Prerequisite<?>>of();
+        } else { 
+            this.prerequisites = ImmutableSet.<Prerequisite<?>>copyOf(prerequisites);
         }
     }
 
@@ -309,7 +307,7 @@ public class MatchField<F extends OFValueType<F>> {
      */
     public Set<Prerequisite<?>> getPrerequisites() {
         /* assumes non-null; guaranteed by constructor */
-        return Collections.unmodifiableSet(this.prerequisites);
+        return this.prerequisites;
     }
 
 }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -303,8 +303,8 @@ public class MatchField<F extends OFValueType<F>> {
 
     /**
      * Retrieve what also must be matched in order to
-     * use this particular MatchField. The returened
-     * set is read-only and unmodifiable.
+     * use this particular MatchField.
+     *
      * @return unmodifiable view of the prerequisites
      */
     public Set<Prerequisite<?>> getPrerequisites() {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -42,11 +42,8 @@ public class MatchField<F extends OFValueType<F>> {
     private MatchField(final String name, final MatchFields id, Prerequisite<?>... prerequisites) {
         this.name = name;
         this.id = id;
-        if (prerequisites == null) {
-            this.prerequisites = ImmutableSet.<Prerequisite<?>>of();
-        } else { 
-            this.prerequisites = ImmutableSet.<Prerequisite<?>>copyOf(prerequisites);
-        }
+        /* guaranteed non-null (private constructor); 'null' isn't passed as prerequisites */
+        this.prerequisites = ImmutableSet.copyOf(prerequisites);
     }
 
     public final static MatchField<OFPort> IN_PORT =

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -31,15 +31,24 @@ import org.projectfloodlight.openflow.types.VlanPcp;
 import org.projectfloodlight.openflow.types.VxlanNI;
 import org.projectfloodlight.openflow.types.VFI;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.HashSet;
+
 public class MatchField<F extends OFValueType<F>> {
     private final String name;
     public final MatchFields id;
-    private final Prerequisite<?>[] prerequisites;
+    private final Set<Prerequisite<?>> prerequisites;
 
     private MatchField(final String name, final MatchFields id, Prerequisite<?>... prerequisites) {
         this.name = name;
         this.id = id;
-        this.prerequisites = prerequisites;
+        if (prerequisites == null || prerequisites.length == 0) {
+            this.prerequisites = Collections.emptySet();
+        } else {
+            this.prerequisites = new HashSet<Prerequisite<?>>();
+            Collections.addAll(this.prerequisites, prerequisites);
+        }
     }
 
     public final static MatchField<OFPort> IN_PORT =
@@ -290,6 +299,17 @@ public class MatchField<F extends OFValueType<F>> {
             }
         }
         return true;
+    }
+
+    /**
+     * Retrieve what also must be matched in order to
+     * use this particular MatchField. The returened
+     * set is read-only and unmodifiable.
+     * @return unmodifiable view of the prerequisites
+     */
+    public Set<Prerequisite<?>> getPrerequisites() {
+        /* assumes non-null; guaranteed by constructor */
+        return Collections.unmodifiableSet(this.prerequisites);
     }
 
 }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
@@ -1,8 +1,7 @@
 package org.projectfloodlight.openflow.protocol.match;
 
-import java.util.HashSet;
 import java.util.Set;
-import java.util.Collections;
+import com.google.common.collect.ImmutableSet;
 
 import org.projectfloodlight.openflow.types.OFValueType;
 
@@ -13,15 +12,13 @@ public class Prerequisite<T extends OFValueType<T>> {
 
     @SafeVarargs
     public Prerequisite(MatchField<T> field, OFValueType<T>... values) {
-        this.values = new HashSet<OFValueType<T>>();
         this.field = field;
         if (values == null || values.length == 0) {
             this.any = true;
+            this.values = ImmutableSet.<OFValueType<T>>of();
         } else {
             this.any = false;
-            for (OFValueType<T> value : values) {
-                this.values.add(value);
-            }
+            this.values = ImmutableSet.<OFValueType<T>>copyOf(values);
         }
     }
 
@@ -49,7 +46,7 @@ public class Prerequisite<T extends OFValueType<T>> {
      * @return unmodifiable set of possible values
      */
     public Set<OFValueType<T>> getValues() {
-        return Collections.unmodifiableSet(this.values);   
+        return this.values;   
     }
 
     /**

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
@@ -13,12 +13,13 @@ public class Prerequisite<T extends OFValueType<T>> {
     @SafeVarargs
     public Prerequisite(MatchField<T> field, OFValueType<T>... values) {
         this.field = field;
+        /* possible null values, since public constructor */
         if (values == null || values.length == 0) {
             this.any = true;
-            this.values = ImmutableSet.<OFValueType<T>>of();
+            this.values = ImmutableSet.of();
         } else {
             this.any = false;
-            this.values = ImmutableSet.<OFValueType<T>>copyOf(values);
+            this.values = ImmutableSet.copyOf(values);
         }
     }
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
@@ -2,6 +2,7 @@ package org.projectfloodlight.openflow.protocol.match;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Collections;
 
 import org.projectfloodlight.openflow.types.OFValueType;
 
@@ -40,6 +41,24 @@ public class Prerequisite<T extends OFValueType<T>> {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Get valid/possible values for this prerequisite match.
+     *
+     * @return unmodifiable set of possible values
+     */
+    public Set<OFValueType<T>> getValues() {
+        return Collections.unmodifiableSet(this.values);   
+    }
+
+    /**
+     * Get the MatchField of this prerequisite.
+     *
+     * @return the MatchField that is required
+     */
+    public MatchField<T> getMatchField() {
+        return this.field; /* immutable */
     }
 
 }


### PR DESCRIPTION
Reviewer: @rlane @andi-bigswitch 

It's useful to see what specific prerequisites are required for a particular MatchField. Having this visibility can allow one to compose flow-mods algorithmically and return more informative error messages for invalid flows without having to redefine the prerequisites at a higher level (i.e. within Floodlight modules) and in duplicate (the information is already set and is contained in OpenFlowJ-Loxi's MatchField.java).