### PR TITLE
standard-1.5:  fixed reserved value

### DIFF
--- a/openflow_input/standard-1.5
+++ b/openflow_input/standard-1.5
@@ -334,7 +334,7 @@ enum ofp_oxs_class(wire_type=uint16_t) {
 };
 
 struct of_stat_v6 (align=8, length_includes_align=False){
-    uint16_t reserved;
+    pad(2); /* reserved */
     uint16_t length;
     list(of_oxs_t) oxs_fields;
 };


### PR DESCRIPTION
Reviewer: @rlane 
CC: @abakagamze 

The 'reserved' value in the stats object was currently exposed as a writeable field. This seemed kind-of ugly. I have made it a static field for now... @rlane - thoughts? - Should we make it a padding instead?