### PR TITLE
Java: V1.5 Stat: add convenience methods akin to Match

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/stat/Stat.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/stat/Stat.java
@@ -11,6 +11,16 @@ public interface Stat extends OFObject {
 
     interface Builder {
         public <F extends OFValueType<F>> F get(StatField<F> field) throws UnsupportedOperationException;
+        /**
+         * Sets a specific value for a stat field.
+         *
+         * @param field Stat field to set.
+         * @param value Value of stat field.
+         * @return the Builder instance used.
+         * @throws UnsupportedOperationException If field is not supported.
+         */
+        public <F extends OFValueType<F>> Builder set(StatField<F> field, F value) throws UnsupportedOperationException;
+
         public boolean supports(StatField<?> field);
         public Stat build();
     }

--- a/java_gen/templates/custom/OFStatV6.Builder.java
+++ b/java_gen/templates/custom/OFStatV6.Builder.java
@@ -1,3 +1,17 @@
+    private OFOxsList.Builder oxsFieldsBuilder;
+
+    private void initBuilder() {
+        if (oxsFieldsBuilder != null)
+            return;
+        oxsFieldsBuilder = new OFOxsList.Builder();
+    }
+
+    private void updateOxsList() {
+        this.oxsFields = this.oxsFieldsBuilder.build();
+        this.oxsFieldsSet = true;
+    }
+
+
 
     @Override
     public <F extends OFValueType<F>> F get(StatField<F> field) throws UnsupportedOperationException{
@@ -11,6 +25,16 @@
 
         return oxs.getValue();
     }
+
+    @Override
+    public <F extends OFValueType<F>> Stat.Builder set(StatField<F> field, F value) {
+        initBuilder();
+        OFOxs<F> oxs = OFFactories.getFactory(OFVersion.${version.constant_version}).oxss().fromValue(value, field);
+        this.oxsFieldsBuilder.set(oxs);
+        updateOxsList();
+        return this;
+    }
+
 
     @Override
     public boolean supports(StatField<?> field){

--- a/java_gen/templates/of_factory_class.java
+++ b/java_gen/templates/of_factory_class.java
@@ -55,7 +55,7 @@ public class ${factory.name} implements ${factory.interface.name} {
     //:: if i.is_virtual:
     //::    continue
     //:: #endif
-    //:: is_match_object = re.match('OFMatch.*', i.name) # i.has_version(factory.version) and model.generate_class(i.versioned_class(factory.version)) and i.versioned_class(factory.version).interface.parent_interface == 'Match'
+    //:: is_match_object = re.match('OFMatch.*', i.name)
     //:: unsupported_match_object = is_match_object and not i.has_version(factory.version)
 
     //:: if len(i.writeable_members) > 0:
@@ -105,7 +105,12 @@ public class ${factory.name} implements ${factory.interface.name} {
 //:: #endif
     }
 
-//:: if factory.interface.name == 'OFOxms':
+//:: if factory.interface.name == "OFFactory":
+    @Override
+    public Stat.Builder buildStat() {
+            return buildStatV6();
+    }
+//:: elif factory.interface.name == 'OFOxms':
     @SuppressWarnings("unchecked")
     public <F extends OFValueType<F>> OFOxm<F> fromValue(F value, MatchField<F> field) {
         switch (field.id) {
@@ -162,6 +167,23 @@ public class ${factory.name} implements ${factory.interface.name} {
                 return null;
         }
     }
+//:: elif factory.interface.name == "OFOxss":
+    @SuppressWarnings("unchecked")
+    public <F extends OFValueType<F>> OFOxs<F> fromValue(F value, StatField<F> field) {
+        switch (field.id) {
+            //:: for oxs_name in model.oxs_map:
+            //::    type_name, value, masked = model.oxs_map[oxs_name]
+            //::    method_name = oxs_name.replace('OFOxs', '')
+            //::    method_name = method_name[0].lower() + method_name[1:]
+            case ${value}:
+                //:: # The cast to Object is done to avoid some javac bug that in some versions cannot handle cast from generic type to other types but Object
+                return (OFOxs<F>)((Object)${method_name}((${type_name})((Object)value)));
+            //:: #endfor
+            default:
+                throw new IllegalArgumentException("No OXM known for match field " + field);
+        }
+    }
+
 //:: #endif
 //:: if factory.interface.xid_generator:
     public long nextXid() {

--- a/java_gen/templates/of_factory_interface.java
+++ b/java_gen/templates/of_factory_interface.java
@@ -55,6 +55,7 @@ public interface ${factory.name}${" extends XidGenerator" if factory.xid_generat
 //:: if factory.name == 'OFFactory':
     Match.Builder buildMatch();
     Match matchWildcardAll();
+    Stat.Builder buildStat();
 //:: #endif
 
     OFMessageReader<${factory.base_class}> getReader();
@@ -64,5 +65,9 @@ public interface ${factory.name}${" extends XidGenerator" if factory.xid_generat
     public <F extends OFValueType<F>> OFOxm<F> fromValue(F value, MatchField<F> field);
     public <F extends OFValueType<F>> OFOxm<F> fromValueAndMask(F value, F mask, MatchField<F> field);
     public <F extends OFValueType<F>> OFOxm<F> fromMasked(Masked<F> masked, MatchField<F> field);
+//:: #endif
+//:: if factory.name == 'OFOxss':
+
+    public <F extends OFValueType<F>> OFOxs<F> fromValue(F value, StatField<F> field);
 //:: #endif
 }


### PR DESCRIPTION
Reviewer: @Sovietaced 
CC: @abakagamze 

Stat mimics the design of the generic Match object. This commit
completes the set of convenience methods that abstract the details
and enable the user to set an abstract statfield.