### PR TITLE
HexString: optimize performance; MacAddress: optimize putTo BVS-5367 LOXI-77

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
@@ -1,6 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
 import java.util.Arrays;
+
 import javax.annotation.Nonnull;
 
 import org.projectfloodlight.openflow.exceptions.OFParseError;
@@ -232,8 +233,7 @@ public class MacAddress implements OFValueType<MacAddress> {
 
     @Override
     public void putTo(PrimitiveSink sink) {
-        sink.putInt((int) (this.rawValue >> 16));
-        sink.putShort((short) (this.rawValue & 0xFFFF));
+        sink.putLong(rawValue);
     }
 
     /*

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/HexString.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/HexString.java
@@ -1,25 +1,28 @@
-/**
- *    Copyright (c) 2008 The Board of Trustees of The Leland Stanford Junior
- *    University
- *
- *    Licensed under the Apache License, Version 2.0 (the "License"); you may
- *    not use this file except in compliance with the License. You may obtain
- *    a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *    License for the specific language governing permissions and limitations
- *    under the License.
- **/
-
 package org.projectfloodlight.openflow.util;
 
-import org.projectfloodlight.openflow.types.U8;
+import io.netty.util.internal.EmptyArrays;
 
-public class HexString {
+/** Utility method to convert hexadecimal string from/to longs and byte arrays.
+ *
+ * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+ */
+public final class HexString {
+
+    private HexString() {}
+
+    /* ================================================================================
+     * Implementation note:
+     * These implementations are optimized for small-O efficiency and thus rather ugly.
+     *
+     * When making changes, make sure *every line* is covered by a unit test.
+     *
+     * Do not use this as a blue print for normal code.
+     * ================================================================================
+     */
+
+    private final static char[] CHARS =
+        { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
     /**
      * Convert a string of bytes to a ':' separated hex string
      *
@@ -27,44 +30,69 @@ public class HexString {
      * @return "0f:ca:fe:de:ad:be:ef"
      */
     public static String toHexString(final byte[] bytes) {
-        int i;
-        String ret = "";
-        String tmp;
-        for (i = 0; i < bytes.length; i++) {
-            if (i > 0)
-                ret += ":";
-            tmp = Integer.toHexString(U8.f(bytes[i]));
-            if (tmp.length() == 1)
-                ret += "0";
-            ret += tmp;
+        int lenBytes = bytes.length;
+        if (lenBytes == 0) {
+            return "";
         }
-        return ret;
+        char arr[] = new char[lenBytes * 2 + (lenBytes -1)];
+
+        int charPos = 0;
+        for (int i=0; i < lenBytes; i++) {
+            if (i > 0) {
+              arr[charPos++] = ':';
+            }
+            arr[charPos++] = CHARS[ (bytes[i] >>> 4) & 0xF ];
+            arr[charPos++] = CHARS[ bytes[i] & 0xF ];
+        }
+        return new String(arr, 0, arr.length);
     }
 
-    public static String toHexString(final long val, final int padTo) {
-        char arr[] = Long.toHexString(val).toCharArray();
-        String ret = "";
-        // prepend the right number of leading zeros
-        int i = 0;
-        for (; i < (padTo * 2 - arr.length); i++) {
-            ret += "0";
-            if ((i % 2) != 0)
-                ret += ":";
+    public static String toHexString(long val, final int padTo) {
+        int valBytes = (64 - Long.numberOfLeadingZeros(val) + 7)/8;
+        int lenBytes = valBytes > padTo ? valBytes : padTo;
+
+        char arr[] = new char[lenBytes * 2 + (lenBytes -1)];
+
+        // fill char array from the last position, shifting val by 4 bits
+        for (int charPos = arr.length - 1; charPos >= 0; charPos--) {
+            if ((charPos + 1) % 3 == 0) {
+                // every third char is a colon
+                arr[charPos] = ':';
+            } else {
+                arr[charPos] = CHARS[((int) val) & 0xF];
+                val >>>= 4;
+            }
         }
-        for (int j = 0; j < arr.length; j++) {
-            ret += arr[j];
-            if ((((i + j) % 2) != 0) && (j < (arr.length - 1)))
-                ret += ":";
-        }
-        return ret;
+        return new String(arr, 0, arr.length);
     }
 
     public static String toHexString(final long val) {
         return toHexString(val, 8);
     }
 
+
+    /** Deprecated version of {@link #toBytes(String)}.
+     *
+     * @throws NumberFormatException
+     * @{@link Deprecated} because of inconsistent naming
+     */
+    @Deprecated
+    public static byte[] fromHexString(final String values) throws NumberFormatException {
+        return toBytes(values);
+    }
+
+    /** state constants for toBytes */
+    /** expecting first digit */
+    private final static int FIRST_DIGIT = 1;
+    /** expecting second digit or colon */
+    private static final int SECOND_DIGIT_OR_COLON = 2;
+    /** expecting colon */
+    private static final int COLON = 3;
+    /** save byte and move back to FIRST_DIGIT */
+    private static final int SAVE_BYTE = 4;
+
     /**
-     * Convert a string of hex values into a string of bytes
+     * Convert a string of hex values into a string of bytes.
      *
      * @param values
      *            "0f:ca:fe:de:ad:be:ef"
@@ -72,29 +100,103 @@ public class HexString {
      * @throws NumberFormatException
      *             If the string can not be parsed
      */
-    public static byte[] fromHexString(final String values) throws NumberFormatException {
-        String[] octets = values.split(":");
-        byte[] ret = new byte[octets.length];
+    public static byte[] toBytes(final String values) throws NumberFormatException {
+        int start = 0;
+        int len = values.length();
 
-        for (int i = 0; i < octets.length; i++) {
-            if (octets[i].length() > 2)
-                throw new NumberFormatException("Invalid octet length");
-            ret[i] = Integer.valueOf(octets[i], 16).byteValue();
+        if (len == 0) {
+            return EmptyArrays.EMPTY_BYTES;
         }
-        return ret;
+
+        int numColons = 0;
+        for (int i=0; i < len; i++) {
+            if (values.charAt(i) == ':') {
+                numColons++;
+            }
+        }
+
+        byte[] res = new byte[numColons+1];
+        int pos = 0;
+
+        int state = FIRST_DIGIT;
+
+        byte b = 0;
+        while (start < len) {
+            char c = values.charAt(start++);
+            switch (state) {
+                case FIRST_DIGIT:
+                    int digit = Character.digit(c, 16);
+                    if(digit < 0) {
+                        throw new NumberFormatException("Invalid char at index " + start + ": " + values);
+                    }
+                    b = (byte) digit;
+                    state = start < len ? SECOND_DIGIT_OR_COLON : SAVE_BYTE;
+                    break;
+                case SECOND_DIGIT_OR_COLON:
+                    if(c != ':') {
+                        int digit2 = Character.digit(c, 16);
+                        if(digit2 < 0) {
+                            throw new NumberFormatException("Invalid char at index " + start + ": " + values);
+                        }
+                        b =  (byte) ((b<<4) | digit2);
+                        state = start < len ? COLON : SAVE_BYTE;
+                    } else {
+                        state = SAVE_BYTE;
+                    }
+                    break;
+                case COLON:
+                    if(c != ':') {
+                        throw new NumberFormatException("Separator expected at index " + start + ": " + values);
+                    }
+                    state = SAVE_BYTE;
+                    break;
+                default:
+                    throw new IllegalStateException("Should not be in state " + state);
+            }
+            if (state == SAVE_BYTE) {
+                res[pos++] = b;
+                b = 0;
+                state = FIRST_DIGIT;
+            }
+        }
+        if (pos != res.length) {
+            // detects a mal-formed input string, e.g., "01:02:"
+            throw new NumberFormatException("Invalid hex string: " + values);
+        }
+
+        return res;
     }
 
     public static long toLong(String value) throws NumberFormatException {
-        String[] octets = value.split(":");
-        if (octets.length > 8)
-            throw new NumberFormatException("Input string is too big to fit in long: " + value);
-        long l = 0;
-        for (String octet: octets) {
-            if (octet.length() > 2)
-                throw new NumberFormatException("Each colon-separated byte component must consist of 1 or 2 hex digits: " + value);
-            short s = Short.parseShort(octet, 16);
-            l = (l << 8) + s;
+        int shift = 0;
+        long result = 0L;
+
+        int sinceLastSeparator = 0;
+        for (int charPos=value.length() - 1; charPos >= 0; charPos--) {
+            char c = value.charAt(charPos);
+            if (c == ':') {
+                if (sinceLastSeparator == 0) {
+                    throw new NumberFormatException("Expected hex digit at index " + charPos +": " + value);
+                } else if(sinceLastSeparator == 1) {
+                    shift += 4;
+                }
+                sinceLastSeparator = 0;
+            } else {
+                int digit = Character.digit(c, 16);
+                if (digit < 0) {
+                    throw new NumberFormatException("Invalid hex digit at index " + charPos +": " + value);
+                }
+                result |= ((long) digit) << shift;
+                shift +=4;
+                sinceLastSeparator++;
+                if (sinceLastSeparator > 2) {
+                    throw new NumberFormatException("Expected colon at index " + charPos +": " + value);
+                }
+            }
+            if (shift > 64) {
+                throw new NumberFormatException("Too many bytes in hex string to convert to long: " + value);
+            }
         }
-        return l;
+        return result;
     }
 }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/HexString.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/HexString.java
@@ -37,13 +37,17 @@ public final class HexString {
         char arr[] = new char[lenBytes * 2 + (lenBytes -1)];
 
         int charPos = 0;
-        for (int i=0; i < lenBytes; i++) {
-            if (i > 0) {
-              arr[charPos++] = ':';
-            }
+        int i = 0;
+
+        for (;;) {
             arr[charPos++] = CHARS[ (bytes[i] >>> 4) & 0xF ];
             arr[charPos++] = CHARS[ bytes[i] & 0xF ];
+            if (++i >= lenBytes) {
+                break;
+            }
+            arr[charPos++] = ':';
         }
+
         return new String(arr, 0, arr.length);
     }
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/util/HexStringTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/util/HexStringTest.java
@@ -17,14 +17,21 @@
 
 package org.projectfloodlight.openflow.util;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.Random;
 
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Does hexstring conversion work?
  *
  * @author Rob Sherwood (rob.sherwood@stanford.edu)
+ * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
  */
 public class HexStringTest {
 
@@ -41,7 +48,7 @@ public class HexStringTest {
         String dpidStr = "3e:1f:01:fc:72:8c:63:31";
         long valid = 0x3e1f01fc728c6331L;
         long testLong = HexString.toLong(dpidStr);
-        assertEquals(valid, testLong);
+        assertEquals("was: " + Long.toHexString(testLong), valid, testLong);
     }
 
     @Test
@@ -49,7 +56,7 @@ public class HexStringTest {
         String dpidStr = "1f:1:fc:72:3:f:31";
         long valid = 0x1f01fc72030f31L;
         long testLong = HexString.toLong(dpidStr);
-        assertEquals(valid, testLong);
+        assertEquals("was: " + Long.toHexString(testLong), valid, testLong);
     }
 
     @Test
@@ -76,13 +83,17 @@ public class HexStringTest {
     }
 
     @Test(expected=NumberFormatException.class)
+    public void testToLongErrorColonAtEnd() {
+        HexString.toLong("03:01:");
+    }
+
+    @Test(expected=NumberFormatException.class)
     public void testToLongErrorInvalidHexDigit() {
         HexString.toLong("ss:01");
     }
 
-    @Test(expected=NumberFormatException.class)
     public void testToLongErrorEmptyString() {
-        HexString.toLong("");
+        assertThat(HexString.toLong(""), equalTo(0L));
     }
 
 
@@ -94,10 +105,138 @@ public class HexStringTest {
         assertEquals(valid, testString);
     }
 
-    @Test(expected=NumberFormatException.class)
-    public void testFromHexStringError() {
-        String invalidStr = "00:00:00:00:00:00:ffff";
-        HexString.fromHexString(invalidStr);
+    @Test
+    public void testToStringBytes2() {
+        byte[] dpid = { 1, 2, 3, 4 };
+        String valid = "01:02:03:04";
+        String testString = HexString.toHexString(dpid);
+        assertEquals(valid, testString);
     }
+
+    @Test
+    public void testToStringBytes3() {
+        byte[] dpid = { (byte) 0xff };
+        String valid = "ff";
+        String testString = HexString.toHexString(dpid);
+        assertEquals(valid, testString);
+    }
+
+    @Test
+    public void testToStringEmpty() {
+        byte[] dpid = { };
+        String valid = "";
+        String testString = HexString.toHexString(dpid);
+        assertEquals(valid, testString);
+    }
+
+    @Test
+    public void testToStringLong() {
+        byte[] dpid = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+        String valid = "01:02:03:04:05:06:07:08:09:0a:0b:0c:0d:0e:0f";
+        String testString = HexString.toHexString(dpid);
+        assertEquals(valid, testString);
+    }
+
+    @Test
+    public void testToZero() {
+        byte[] dpid = { 0, 0, 0, 0};
+        String valid = "00:00:00:00";
+        String testString = HexString.toHexString(dpid);
+        assertEquals(valid, testString);
+    }
+
+    @Test
+    public void testToStringFromLong() {
+        assertThat(HexString.toHexString(0x0L), equalTo("00:00:00:00:00:00:00:00"));
+        assertThat(HexString.toHexString(0x00_00_00_00_00_00_00_01L), equalTo("00:00:00:00:00:00:00:01"));
+        assertThat(HexString.toHexString(0x01_02_03_04_05_06_07_08L), equalTo("01:02:03:04:05:06:07:08"));
+        assertThat(HexString.toHexString(0x00_00_ff_fe_fd_fc_fb_fa_f9_f8L), equalTo("ff:fe:fd:fc:fb:fa:f9:f8"));
+        assertThat(HexString.toHexString(0x80_70_60_50_40_30_20_10L), equalTo("80:70:60:50:40:30:20:10"));
+    }
+
+    @Test
+    public void testToStringFromLongPad6() {
+        assertThat(HexString.toHexString(0x0L, 6), equalTo("00:00:00:00:00:00"));
+        assertThat(HexString.toHexString(0x00_00_00_00_00_00_00_01L, 6), equalTo("00:00:00:00:00:01"));
+        assertThat(HexString.toHexString(0x00_00_01_02_03_04_05_06L, 6), equalTo("01:02:03:04:05:06"));
+        assertThat(HexString.toHexString(0x00_00_ff_fe_fd_fc_fb_faL, 6), equalTo("ff:fe:fd:fc:fb:fa"));
+        // when supplying a value longer than 6, it is displayed completely
+        assertThat(HexString.toHexString(0x80_70_60_50_40_30_20_10L, 6), equalTo("80:70:60:50:40:30:20:10"));
+    }
+
+    @Test
+    public void testToBytes() {
+        assertThat(HexString.toBytes(""), equalTo(new byte[]{}));
+        assertThat(HexString.toBytes("1"), equalTo(new byte[]{0x01}));
+        assertThat(HexString.toBytes("f"), equalTo(new byte[]{0x0f}));
+        assertThat(HexString.toBytes("10"), equalTo(new byte[]{(byte) 0x10}));
+        assertThat(HexString.toBytes("80"), equalTo(new byte[]{(byte) 0x80}));
+        assertThat(HexString.toBytes("ff"), equalTo(new byte[]{(byte) 0xff}));
+        assertThat(HexString.toBytes("0:0"), equalTo(new byte[]{(byte) 0x00, 0x00}));
+        assertThat(HexString.toBytes("00:00"), equalTo(new byte[]{(byte) 0x00, 0x00}));
+        assertThat(HexString.toBytes("0:1"), equalTo(new byte[]{(byte) 0x00, 0x01}));
+        assertThat(HexString.toBytes("00:1"), equalTo(new byte[]{(byte) 0x00, 0x01}));
+        assertThat(HexString.toBytes("0:01"), equalTo(new byte[]{(byte) 0x00, 0x01}));
+        assertThat(HexString.toBytes("1:0"), equalTo(new byte[]{(byte) 0x01, 0x00}));
+        assertThat(HexString.toBytes("01:00"), equalTo(new byte[]{(byte) 0x01, 0x00}));
+        assertThat(HexString.toBytes("01:02:03:04"), equalTo(new byte[]{(byte) 0x01, 0x02, 03, 04}));
+        assertThat(HexString.toBytes("ff:fe:03:04"), equalTo(new byte[]{(byte) 0xff, (byte) 0xfe, 03, 04}));
+        assertThat(HexString.toBytes("ff:fe:3:4"), equalTo(new byte[]{(byte) 0xff, (byte) 0xfe, 03, 04}));
+        assertThat(HexString.toBytes("01:02:03:04:05:06"), equalTo(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06 }));
+        assertThat(HexString.toBytes("ff:1:fe:2:fd"),
+                equalTo(new byte[]{(byte) 0xff, 0x01, (byte) 0xfe, 0x02, (byte) 0xfd}));
+
+    }
+    @Test
+    public void testToBytesRandom() {
+        Random r = new Random();
+        for(int length: ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 15, 16, 32, 63, 64, 128, 255, 256, 511, 512, 1023, 1024)) {
+            StringBuilder build = new StringBuilder();
+            byte[] bytes = new byte[length];
+            for(int i=0; i<length; i++) {
+                byte b = (byte) r.nextInt(256);
+                build.append(String.format("%02x", b));
+                if(i < length-1) {
+                    build.append(":");
+                }
+                bytes[i] = b;
+            }
+            assertThat("For length "+ length + ", ",
+                    HexString.toBytes(build.toString()),
+                    equalTo(bytes));
+        }
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testToBytesError() {
+        String invalidStr = "00:00:00:00:00:00:ffff";
+        HexString.toBytes(invalidStr);
+    }
+
+
+    @Test(expected=NumberFormatException.class)
+    public void testToBytesError2() {
+        String invalidStr = ":01:02:03";
+        HexString.toBytes(invalidStr);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testToBytesError3() {
+        String invalidStr = "01::02:03";
+        HexString.toBytes(invalidStr);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testBoBytesError4() {
+        String invalidStr = "01:02:03:";
+        HexString.toBytes(invalidStr);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testtoBytesError5() {
+        String invalidStr = "01:0X";
+        HexString.toBytes(invalidStr);
+    }
+
 }
 


### PR DESCRIPTION
Reviewer: @ronaldchl @Sovietaced 

While debugging a performance problem related to `MacAddress.toString`, I noticed that the `HexString` conversion code we had was really old and inefficient. This code was even using anti-patterns like concatenating Strings without a StringBuilder (!).

These routines are used in a quite a lot of serialization cases, e.g., for DatapathIds.

This commit replaces the code with optimized implementations. These are necessarily relatively ugly and procedural.

JMH benchmarks show the new versions to be between 3.5 and 9.1x faster.

JMH Benchmark results:
Old versions:
```
Benchmark                                    Mode  Cnt        Score       Error  Units
HexStringBenchmark.testBytes6ToHexString    thrpt  200  5482128.668 ± 10011.236  ops/s
HexStringBenchmark.testBytes8ToHexString    thrpt  200  4097441.103 ±  9869.569  ops/s
HexStringBenchmark.testLongToHexStringPad6  thrpt  200  6015404.366 ± 16095.163  ops/s
HexStringBenchmark.testLongToHexStringPad8  thrpt  200  4499879.492 ±  7371.526  ops/s
HexStringBenchmark.testMacToString          thrpt  200  6039423.717 ± 14960.774  ops/s
HexStringBenchmark.testToBytes              thrpt  200  4320243.806 ± 12942.870  ops/s
HexStringBenchmark.testToLong               thrpt  200  5733672.143 ± 26865.832  ops/s
```

New versions:
```
Benchmark                                    Mode  Cnt         Score        Error  Units
HexStringBenchmark.testBytes6ToHexString    thrpt  200  46454822.004 ± 131143.806  ops/s
HexStringBenchmark.testBytes8ToHexString    thrpt  200  37602862.513 ±  92041.035  ops/s
HexStringBenchmark.testLongToHexStringPad6  thrpt  200  38286359.083 ±  80960.505  ops/s
HexStringBenchmark.testLongToHexStringPad8  thrpt  200  30273992.729 ±  55125.764  ops/s
HexStringBenchmark.testMacToString          thrpt  200  37012667.642 ±  93106.031  ops/s
HexStringBenchmark.testToBytes              thrpt  200  15237921.501 ±  16622.545  ops/s
HexStringBenchmark.testToLong               thrpt  200  30268266.435 ±  24626.181  ops/s
```