### PR TITLE
OF1.0 patch for ICMP type and code matches

### DIFF
--- a/java_gen/templates/custom/OFMatchV1Ver10.Builder.java
+++ b/java_gen/templates/custom/OFMatchV1Ver10.Builder.java
@@ -64,11 +64,11 @@
                 case SCTP_DST:
                     result = tcpDst;
                     break;
-                case ICMPV4_TYPE:
-                    result = tcpSrc;
+               case ICMPV4_TYPE:
+                    result = ICMPv4Type.of((short) tcpSrc.getPort());
                     break;
-                case ICMPV4_CODE:
-                    result = tcpDst;
+               case ICMPV4_CODE:
+                    result = ICMPv4Code.of((short) tcpDst.getPort());
                     break;
                 // NOT SUPPORTED:
                 default:

--- a/java_gen/templates/custom/OFMatchV1Ver10.java
+++ b/java_gen/templates/custom/OFMatchV1Ver10.java
@@ -101,10 +101,10 @@
                 result = tcpDst;
                 break;
             case ICMPV4_TYPE:
-                result = tcpSrc;
+                result = ICMPv4Type.of((short) tcpSrc.getPort());
                 break;
             case ICMPV4_CODE:
-                result = tcpDst;
+                result = ICMPv4Code.of((short) tcpDst.getPort());
                 break;
             // NOT SUPPORTED:
             default:

--- a/java_gen/templates/custom/OFMatchV1Ver10.java
+++ b/java_gen/templates/custom/OFMatchV1Ver10.java
@@ -365,6 +365,8 @@
                 builder.add(MatchField.TCP_SRC);
             } else if (ipProto == IpProtocol.SCTP) {
                 builder.add(MatchField.SCTP_SRC);
+            } else if (ipProto == IpProtocol.ICMP) {
+                builder.add(MatchField.ICMPV4_TYPE);
             } else {
                 throw new UnsupportedOperationException(
                         "Unsupported IP protocol for matching on source port " + ipProto);
@@ -377,6 +379,8 @@
                 builder.add(MatchField.TCP_DST);
             } else if (ipProto == IpProtocol.SCTP) {
                 builder.add(MatchField.SCTP_DST);
+            } else if (ipProto == IpProtocol.ICMP) {
+                builder.add(MatchField.ICMPV4_CODE);
             } else {
                 throw new UnsupportedOperationException(
                         "Unsupported IP protocol for matching on destination port " + ipProto);


### PR DESCRIPTION
Reviewer: @rlane @andi-bigswitch 

Allow using the transport source and destination port match fields for ICMP type and code, respectively. This was mostly done, but was incomplete in getMatchFields(), resulting in the thrown exception.