### PR TITLE
Patch to optionally ignore the XID field in OFMessage and other types

### DIFF
--- a/java_gen/templates/of_class.java
+++ b/java_gen/templates/of_class.java
@@ -419,6 +419,42 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
         return true;
     }
 
+    //:: for prop in msg.data_members:
+    //:: if prop.name == 'xid':
+    public boolean equalsIgnoreXid(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        //:: if len(msg.data_members) > 0:
+        ${msg.name} other = (${msg.name}) obj;
+        //:: #endif
+
+        //:: for prop in msg.data_members:
+        //:: if prop.java_type.is_primitive and prop.name == 'xid':
+        // ignore XID
+        //:: elif prop.java_type.is_primitive:
+        if( ${prop.name} != other.${prop.name})
+            return false;
+        //:: elif prop.java_type.is_array:
+        if (!Arrays.equals(${prop.name}, other.${prop.name}))
+                return false;
+        //:: else:
+        if (${prop.name} == null) {
+            if (other.${prop.name} != null)
+                return false;
+        } else if (!${prop.name}.equals(other.${prop.name}))
+            return false;
+        //:: #endif
+        //:: #endfor
+        return true;
+    }
+    //:: break
+    //:: #endif
+    //:: #endfor
+
     @Override
     public int hashCode() {
         //:: if len(msg.data_members) > 0:

--- a/java_gen/templates/of_class.java
+++ b/java_gen/templates/of_class.java
@@ -450,8 +450,8 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
         //:: #endfor
         return true;
     }
-    //:: #endif
 
+    //:: #endif
     @Override
     public int hashCode() {
         //:: if len(msg.data_members) > 0:

--- a/java_gen/templates/of_class.java
+++ b/java_gen/templates/of_class.java
@@ -419,8 +419,7 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
         return true;
     }
 
-    //:: for prop in msg.data_members:
-    //:: if prop.name == 'xid':
+    //:: if filter(lambda m: m.name == 'xid', msg.data_members):
     public boolean equalsIgnoreXid(Object obj) {
         if (this == obj)
             return true;
@@ -451,9 +450,7 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
         //:: #endfor
         return true;
     }
-    //:: break
     //:: #endif
-    //:: #endfor
 
     @Override
     public int hashCode() {


### PR DESCRIPTION
Reviewer: @rlane @andi-bigswitch 

For any class with an XID field (detected by a class field named 'xid'), include an equalsIgnoreXid() function to ignore the XID in the equality check. The assumption, of course, is that the XID field is named 'xid' and is a primitive type ('long' at present). This will allow for the content-comparison of two OFMessages without regard to when they were created (or what the XID was set to).

This will address the long-lived problem in Floodlight of not being able to use the OFMessageDamper to prevent rapid, duplicate messages from being sent to the switch. A workaround has been used the last couple years that rebuilds the 'other' object in the comparison with the XID of 'this', which is quite inefficient.