### PR TITLE
BVS-6442: Adding MacAddr generation for IPv6 Mcast addresses.

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
@@ -37,6 +37,8 @@ public class MacAddress implements OFValueType<MacAddress> {
     private static final long LLDP_MAC_ADDRESS_VALUE = 0x0180c2000000L;
     private final static MacAddress MULTICAST_BASE_ADDRESS =
            MacAddress.of("01:00:5E:00:00:00");
+    private final static MacAddress IPv6_MULTICAST_BASE_ADDRESS =
+           MacAddress.of("33:33:00:00:00:00");
 
     private static final String FORMAT_ERROR = "Mac address is not well-formed. " +
             "It must consist of 6 hex digit pairs separated by colons or hyphens: ";
@@ -267,6 +269,37 @@ public class MacAddress implements OFValueType<MacAddress> {
         ipLong = ipLong & ipMask;
 
         long macLong = MULTICAST_BASE_ADDRESS.getLong(); // 01:00:5E:00:00:00
+        macLong = macLong | ipLong;
+        MacAddress returnMac = MacAddress.of(macLong);
+
+        return returnMac;
+    }
+
+    /**
+     * Generate a MAC address corresponding to multicast IPv6  address.
+     *
+     * Take the last 4 bytes of IPv6 address and copy them to the base IPv6
+     * multicast mac address - 33:33:00:00:00:00.
+     *
+     * @param ipv6 - IPv6 address corresponding to which multicast MAC addr
+     * need to be generated.
+     * @return - the generated multicast mac address.
+     * @throws IllegalArgumentException if ipv6 address is not a valid IPv6
+     * multicast address.
+     */
+    @Nonnull
+    public static MacAddress forIPv6MulticastAddr(IPv6Address ipv6)
+            throws IllegalArgumentException {
+        if (!ipv6.isMulticast()) {
+            throw new IllegalArgumentException(
+                    "Not a Multicast IPv6Address\"" + ipv6 + "\"");
+        }
+        long ipLong = ((ipv6.getUnsignedShortWord(6) << 16) |
+                                         ipv6.getUnsignedShortWord(7));
+        long ipMask = 0xFFFFFFFFl;
+        ipLong = ipLong & ipMask;
+
+        long macLong = IPv6_MULTICAST_BASE_ADDRESS.getLong();//33:33:00:00:00:00
         macLong = macLong | ipLong;
         MacAddress returnMac = MacAddress.of(macLong);
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/MacAddress.java
@@ -35,9 +35,9 @@ public class MacAddress implements OFValueType<MacAddress> {
 
     private static final long LLDP_MAC_ADDRESS_MASK = 0xfffffffffff0L;
     private static final long LLDP_MAC_ADDRESS_VALUE = 0x0180c2000000L;
-    private final static MacAddress MULTICAST_BASE_ADDRESS =
+    private final static MacAddress IPV4_MULTICAST_BASE_ADDRESS =
            MacAddress.of("01:00:5E:00:00:00");
-    private final static MacAddress IPv6_MULTICAST_BASE_ADDRESS =
+    private final static MacAddress IPV6_MULTICAST_BASE_ADDRESS =
            MacAddress.of("33:33:00:00:00:00");
 
     private static final String FORMAT_ERROR = "Mac address is not well-formed. " +
@@ -268,7 +268,7 @@ public class MacAddress implements OFValueType<MacAddress> {
         int ipMask = 0x007FFFFF;
         ipLong = ipLong & ipMask;
 
-        long macLong = MULTICAST_BASE_ADDRESS.getLong(); // 01:00:5E:00:00:00
+        long macLong = IPV4_MULTICAST_BASE_ADDRESS.getLong(); // 01:00:5E:00:00:00
         macLong = macLong | ipLong;
         MacAddress returnMac = MacAddress.of(macLong);
 
@@ -299,7 +299,7 @@ public class MacAddress implements OFValueType<MacAddress> {
         long ipMask = 0xFFFFFFFFl;
         ipLong = ipLong & ipMask;
 
-        long macLong = IPv6_MULTICAST_BASE_ADDRESS.getLong();//33:33:00:00:00:00
+        long macLong = IPV6_MULTICAST_BASE_ADDRESS.getLong();//33:33:00:00:00:00
         macLong = macLong | ipLong;
         MacAddress returnMac = MacAddress.of(macLong);
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/MacAddressTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/MacAddressTest.java
@@ -211,4 +211,29 @@ public class MacAddressTest {
             assertThat(mac, is(MacAddress.of(s)));
         }
     }
+
+    @Test
+    public void forIPv6MulticastAddr() {
+        IPv6Address ip = IPv6Address.of("ff02::1:ff00:0");
+        MacAddress mac = MacAddress.forIPv6MulticastAddr(ip);
+        MacAddress expectedMac = MacAddress.of("33:33:ff:00:00:00");
+        assertTrue(mac.equals(expectedMac));
+
+        ip = IPv6Address.of("ff02::1:ff01:0203");
+        mac = MacAddress.forIPv6MulticastAddr(ip);
+        expectedMac = MacAddress.of("33:33:ff:01:02:03");
+        assertTrue(mac.equals(expectedMac));
+
+        ip = IPv6Address.of("ff02::1:0102:0304");
+        mac = MacAddress.forIPv6MulticastAddr(ip);
+        expectedMac = MacAddress.of("33:33:01:02:03:04");
+        assertTrue(mac.equals(expectedMac));
+
+        ip = IPv6Address.of("2001::1:0102:0304");
+        try {
+            mac = MacAddress.forIPv6MulticastAddr(ip);
+        } catch(IllegalArgumentException e) {
+                // ok
+        }
+    }
 }


### PR DESCRIPTION
Reviewer: @andi-bigswitch @ronaldchl 
This is to add a method to generate MacAddr corresponding to IPv6 Multicast address. A JUNIT test has been added too.
