### PR TITLE
Correct Javadoc to fix build failure when running 'make package-java'

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Match.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Match.java
@@ -56,6 +56,7 @@ public interface Match extends OFObject {
      * </ul>
      * If one of the above conditions does not hold, returns null. Value is returned masked if partially wildcarded.
      *
+     * @param <F> MatchField type
      * @param field Match field to retrieve
      * @return Value of match field (may be masked), or <code>null</code> if field is one of the conditions above does not hold.
      * @throws UnsupportedOperationException If field is not supported.
@@ -67,6 +68,7 @@ public interface Match extends OFObject {
      * Prerequisite: field is partially masked.
      * If prerequisite is not met, a <code>null</code> is returned.
      *
+     * @param <F> MatchField type
      * @param field Match field to retrieve.
      * @return Masked value of match field or null if no mask is set.
      * @throws UnsupportedOperationException If field is not supported.
@@ -128,7 +130,7 @@ public interface Match extends OFObject {
      * match. This includes the match fields that are exact or masked match
      * (but not fully wildcarded).
      *
-     * @return
+     * @return the Iterable of MatchField
      */
     public Iterable<MatchField<?>> getMatchFields();
 
@@ -169,6 +171,7 @@ public interface Match extends OFObject {
         /**
          * Sets a specific exact value for a field.
          *
+         * @param <F> MatchField and value type
          * @param field Match field to set.
          * @param value Value of match field.
          * @return the Builder instance used.
@@ -179,6 +182,7 @@ public interface Match extends OFObject {
         /**
          * Sets a masked value for a field.
          *
+         * @param <F> MatchField, value, and mask type
          * @param field Match field to set.
          * @param value Value of field.
          * @param mask Mask value.
@@ -190,6 +194,7 @@ public interface Match extends OFObject {
         /**
          * Sets a masked value for a field.
          *
+         * @param <F> MatchField and value with mask type
          * @param field Match field to set.
          * @param valueWithMask Compound Masked object contains the value and the mask.
          * @return the Builder instance used.
@@ -200,6 +205,7 @@ public interface Match extends OFObject {
         /**
          * Unsets any value given for the field and wildcards it so that it matches any value.
          *
+         * @param <F> MatchField type
          * @param field Match field to unset.
          * @return the Builder instance used.
          * @throws UnsupportedOperationException If field is not supported.

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/stat/Stat.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/stat/Stat.java
@@ -14,6 +14,7 @@ public interface Stat extends OFObject {
         /**
          * Sets a specific value for a stat field.
          *
+         * @param <F> StatField type
          * @param field Stat field to set.
          * @param value Value of stat field.
          * @return the Builder instance used.

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/HashValue.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/HashValue.java
@@ -7,7 +7,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * @author Andreas Wundsam {@literal <}andreas.wundsam@bigswitch.com{@literal >}
  *
- * @param <H> - this type, for return type safety.
+ * @param H - this type, for return type safety.
  */
 @Immutable
 public interface HashValue<H extends HashValue<H>> {
@@ -20,7 +20,7 @@ public interface HashValue<H extends HashValue<H>> {
     /** perform an arithmetic addition of this value and other. Wraps around on
      * overflow of the defined word size.
      *
-     * @param other
+     * @param other the other value to add to this
      * @return this + other
      */
     H add(H other);
@@ -29,7 +29,7 @@ public interface HashValue<H extends HashValue<H>> {
      * arithmetically substract the given 'other' value from this value.
      * around on overflow.
      *
-     * @param other
+     * @param other the other value to subtract from this
      * @return this - other
      */
     H subtract(H other);
@@ -37,32 +37,53 @@ public interface HashValue<H extends HashValue<H>> {
     /** @return the bitwise inverse of this value */
     H inverse();
 
-    /** or this value with another value value of the same type */
+    /** 
+     * or this value with another value value of the same type 
+     * 
+     * @param other the other value to bitwise or with this
+     * @return this | other
+     */
     H or(H other);
 
-    /** and this value with another value value of the same type */
+    /** 
+     * and this value with another value value of the same type 
+     * 
+     * @param other the other value to bitwise and with this
+     * @return this {@literal &} other
+     */
     H and(H other);
 
-    /** xor this value with another value value of the same type */
+    /** 
+     * xor this value with another value value of the same type 
+     *
+     * @param other the other value to bitwise xor with this
+     * @return this XOR other
+     */
     H xor(H other);
 
-    /** create and return a builder */
+    /** 
+     * create and return a builder 
+     *
+     * @return builder
+     */
     Builder<H> builder();
 
-    /** a mutator for HashValues. Allows perfomring a series of
-     *  operations on a hashv value without the associated cost of object
-     *  reallocation.
+    /** 
+     * a mutator for HashValues. Allows perfomring a series of
+     * operations on a hashv value without the associated cost of object
+     * reallocation.
      *
      * @author Andreas Wundsam {@literal <}andreas.wundsam@bigswitch.com{@literal >}
      *
      * @param <H> - the hashvalue
      */
     public interface Builder<H> {
-        /** perform an arithmetic addition of this value and other. Wraps around on
+        /** 
+         * perform an arithmetic addition of this value and other. Wraps around on
          * overflow of the defined word size.
          *
-         * @param other
-         * @return this mutator
+         * @param other the other value to add to this
+         * @return this mutator containing this + other
          */
         Builder<H> add(H other);
 
@@ -70,33 +91,47 @@ public interface HashValue<H extends HashValue<H>> {
          * arithmetically substract the given 'other' value from the value stored in this mutator.
          * around on overflow.
          *
-         * @param other
-         * @return this mutator
+         * @param other the other value to subtract from this
+         * @return this mutator containing this - other
          */
         Builder<H> subtract(H other);
 
-        /** bitwise invert the value stored in this mutator
+        /** 
+         * bitwise invert the value stored in this mutator
          *
-         * @return this mutator
+         * @return this mutator containing ~this
          */
         Builder<H> invert();
 
-        /** or the value stored in this mutator with another value value of the same type
-        * @return this mutator
-        */
+        /** 
+         * or the value stored in this mutator with another value value of the same type
+         *
+         * @param other the other value to bitwise or with this
+         * @return this mutator containing this | other
+         */
         Builder<H> or(H other);
 
-        /** and the value stored in this mutator with another value value of the same type
-        * @return this mutator
-        */
+        /** 
+         * and the value stored in this mutator with another value value of the same type
+         *
+         * @param other the other value to bitwise and with this
+         * @return this mutator containing this {@literal &} other
+         */
         Builder<H> and(H other);
 
-        /** xor the value stored in this mutator with another value value of the same type
-        * @return this mutator
-        */
+        /** 
+         * xor the value stored in this mutator with another value value of the same type
+         *
+         * @param other the other value to bitwise exclusive or with this
+         * @return this mutator containing this XOR other
+         */
         Builder<H> xor(H other);
 
-        /** @return the hash value */
+        /** 
+         * construct an immutable value from the value defined in the builder
+         *
+         * @return the hash value 
+         */
         public H build();
     }
 }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPAddress.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPAddress.java
@@ -42,6 +42,7 @@ public abstract class IPAddress<F extends IPAddress<F>> implements OFValueType<F
      * <li>the {@link IPv4Address} of {@code 0.0.0.0}
      * <li>the {@link IPv6Address} of {@code ::}
      * </ul>
+     * @return {@code true} if the IPAddress is unspecified, false otherwise
      */
     public abstract boolean isUnspecified();
 
@@ -53,6 +54,7 @@ public abstract class IPAddress<F extends IPAddress<F>> implements OFValueType<F
      * <li>any {@link IPv4Address} within {@code 127.0.0.0/8}
      * <li>the {@link IPv6Address} of {@code ::1}
      * </ul>
+     * @return {@code true} if the IPAddress is a loopback address, false otherwise
      */
     public abstract boolean isLoopback();
 
@@ -64,6 +66,7 @@ public abstract class IPAddress<F extends IPAddress<F>> implements OFValueType<F
      * <li>any {@link IPv4Address} within {@code 169.254.0.0/16}
      * <li>any {@link IPv6Address} within {@code fe80::/10}
      * </ul>
+     * @return {@code true} if the IPAddress is a link local address, false otherwise
      */
     public abstract boolean isLinkLocal();
 
@@ -153,6 +156,7 @@ public abstract class IPAddress<F extends IPAddress<F>> implements OFValueType<F
      * <li>will not carry a non-zero scope ID or scoped interface,
      *     in the case of {@link Inet6Address}
      * </ul>
+     * @return an {@link InetAddress} object representing this IP address
      */
     @Nonnull
     public abstract InetAddress toInetAddress();

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
@@ -189,6 +189,12 @@ public class IPv4Address extends IPAddress<IPv4Address> implements Writeable {
      *
      * @throws IllegalArgumentException if any of the octets were
      *         negative or greater than 255
+     * @param octet1 the highest order byte in network byte order
+     * @param octet2 the 2nd-highest order byte in network byte order
+     * @param octet3 the 2nd-lowest order byte in network byte order
+     * @param octet4 the lowest order byte in network byte order
+     * @return an {@code IPv4Address} object that represents the given
+     * IP address
      */
     @Nonnull
     public static IPv4Address of(

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
@@ -176,6 +176,8 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
      *
      * <p>This method assumes the second (lower-order) 64-bit block to be
      * a 64-bit interface identifier, which may not always be true.
+     * @param macAddress the MAC address to check
+     * @return boolean true or false
      */
     public boolean isModifiedEui64Derived(@Nonnull MacAddress macAddress) {
         return raw2 == toModifiedEui64(macAddress);
@@ -412,6 +414,10 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
      *
      * @throws IllegalArgumentException if the specified network does not
      *         meet the aforementioned requirements
+     * @param network the IPv6 network
+     * @param macAddress the MAC address
+     * @return an {@code IPv6Address} object that represents the given
+     * MAC address in the specified network
      */
     @Nonnull
     public static IPv6Address of(
@@ -555,7 +561,11 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
             throw new IllegalArgumentException("16 bit word index must be in [0,7]");
     }
 
-    /** get the index of the first word where to apply IPv6 zero compression */
+    /** 
+     * get the index of the first word where to apply IPv6 zero compression 
+     *
+     * @return the index
+     */
     public int getZeroCompressStart() {
         int start = Integer.MAX_VALUE;
         int maxLength = -1;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFGroup.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFGroup.java
@@ -79,7 +79,11 @@ public class OFGroup implements OFValueType<OFGroup> {
         }
     }
 
-    /** return the group number as a int32 */
+    /** 
+     * get the group number of this group as a int32 
+     *
+     * @return the integer form of the this group
+     */
     public int getGroupNumber() {
         return groupNumber;
     }

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPort.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPort.java
@@ -161,7 +161,7 @@ public class OFPort implements OFValueType<OFPort> {
      * NOTE: The port object may either be newly allocated or cached. Do not
      * rely on either behavior.
      *
-     * @param portNumber
+     * @param portNumber the integer port number
      * @return a corresponding OFPort
      */
     public static OFPort ofInt(final int portNumber) {
@@ -294,7 +294,12 @@ public class OFPort implements OFValueType<OFPort> {
         }
     }
 
-    /** convenience function: delegates to ofInt */
+    /** 
+     * convenience function: delegates to ofInt 
+     *
+     * @param portNumber the integer port number
+     * @return a corresponding OFPort
+     */
     public static OFPort of(final int portNumber) {
         return ofInt(portNumber);
     }
@@ -305,7 +310,7 @@ public class OFPort implements OFValueType<OFPort> {
      * 32-bit integer value allocated as its port number. NOTE: The port object
      * may either be newly allocated or cached. Do not rely on either behavior.
      *
-     * @param portNumber
+     * @param portNumber the short port number
      * @return a corresponding OFPort
      */
     public static OFPort ofShort(final short portNumber) {
@@ -438,7 +443,11 @@ public class OFPort implements OFValueType<OFPort> {
         }
     }
 
-    /** return the port number as a int32 */
+    /** 
+     * return the port number as a int32 
+     *
+     * @return the port number as an integer
+     */
     public int getPortNumber() {
         return portNumber;
     }
@@ -450,7 +459,8 @@ public class OFPort implements OFValueType<OFPort> {
      *
      * @throws IllegalArgumentException
      *             if a regular port number exceeds the maximum value in OF1.0
-     **/
+     * @return the port number as a short
+     */
     public short getShortPortNumber() {
 
         switch (portNumber) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPortBitMap.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPortBitMap.java
@@ -46,9 +46,13 @@ public class OFPortBitMap extends Masked<OFBitMask128> {
         super(OFBitMask128.NONE, mask);
     }
 
-    /** @return whether or not the given port is logically included in the
-     *  match, i.e., whether a packet from in-port <em>port</em> be matched by
-     *  this OXM.
+    /** 
+     * Check if the given port is logically included in the
+     * match. I.e. will a packet from in-port <em>port</em>
+     * be matched by this OXM?
+     *
+     * @param port the port to check in the match
+     * @return boolean true or false
      */
     public boolean isOn(OFPort port) {
         // see the implementation note above about the logical inversion of the mask
@@ -63,16 +67,19 @@ public class OFPortBitMap extends Masked<OFBitMask128> {
         return builder.build();
     }
 
-    /** @return an OFPortBitmap based on the 'mask' part of an OFBitMask128, as, e.g., returned
-     *  by the switch.
-     **/
+    /** 
+     * @param mask the mask to create the bitmap from
+     * @return an OFPortBitmap based on the 'mask' part of an OFBitMask128, as, e.g., returned
+     * by the switch.
+     */
     public static OFPortBitMap of(OFBitMask128 mask) {
         return new OFPortBitMap(mask);
     }
 
-    /** @return iterating over all ports that are logically included in the
-     *  match, i.e., whether a packet from in-port <em>port</em> be matched by
-     *  this OXM.
+    /** 
+     * @return iterating over all ports that are logically included in the
+     * match, i.e., whether a packet from in-port <em>port</em> be matched by
+     * this OXM.
      */
     public Iterable<OFPort> getOnPorts() {
         ArrayList<OFPort> ports = new ArrayList<>();
@@ -104,17 +111,22 @@ public class OFPortBitMap extends Masked<OFBitMask128> {
 
         }
 
-        /** @return whether or not the given port is logically included in the
-         *  match, i.e., whether a packet from in-port <em>port</em> be matched by
-         *  this OXM.
+        /** 
+         * @param port the port to check if it's being matched by the bitmask
+         * @return whether or not the given port is logically included in the
+         * match, i.e., whether a packet from in-port <em>port</em> be matched by
+         * this OXM.
          */
         public boolean isOn(OFPort port) {
             // see the implementation note above about the logical inversion of the mask
             return !(OFBitMask128.isBitOn(raw1, raw2, port.getPortNumber()));
         }
 
-        /** remove this port from the match, i.e., packets from this in-port
-         *  will NOT be matched.
+        /** 
+         * remove this port from the match, i.e., packets from this in-port
+         * will NOT be matched.
+         * @param port the port to remove from the match
+         * @return this mutator
          */
         public Builder unset(OFPort port) {
             // see the implementation note above about the logical inversion of the mask
@@ -135,8 +147,11 @@ public class OFPortBitMap extends Masked<OFBitMask128> {
             return this;
         }
 
-        /** add this port from the match, i.e., packets from this in-port
-         *  will NOT be matched.
+        /** 
+         * add this port to the match, i.e., packets from this in-port
+         * will be matched.
+         * @param port the port to add to the match
+         * @return this mutator 
          */
         public Builder set(OFPort port) {
             // see the implementation note above about the logical inversion of the mask

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPortBitMap512.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPortBitMap512.java
@@ -46,9 +46,11 @@ public class OFPortBitMap512 extends Masked<OFBitMask512> {
         super(OFBitMask512.NONE, mask);
     }
 
-    /** @return whether or not the given port is logically included in the
-     *  match, i.e., whether a packet from in-port <em>port</em> be matched by
-     *  this OXM.
+    /** 
+     * @param port the port to check
+     * @return whether or not the given port is logically included in the
+     * match, i.e., whether a packet from in-port <em>port</em> be matched by
+     * this OXM.
      */
     public boolean isOn(OFPort port) {
         // see the implementation note above about the logical inversion of the mask
@@ -63,16 +65,19 @@ public class OFPortBitMap512 extends Masked<OFBitMask512> {
         return builder.build();
     }
 
-    /** @return an OFPortBitmap based on the 'mask' part of an OFBitMask512, as, e.g., returned
-     *  by the switch.
-     **/
+    /** 
+     * @param mask the mask used to create the bitmap
+     * @return an OFPortBitmap based on the 'mask' part of an OFBitMask512, as, e.g., returned
+     * by the switch.
+     */
     public static OFPortBitMap512 of(OFBitMask512 mask) {
         return new OFPortBitMap512(mask);
     }
 
-    /** @return iterating over all ports that are logically included in the
-     *  match, i.e., whether a packet from in-port <em>port</em> be matched by
-     *  this OXM.
+    /** 
+     * @return iterating over all ports that are logically included in the
+     * match, i.e., whether a packet from in-port <em>port</em> be matched by
+     * this OXM.
      */
     public Iterable<OFPort> getOnPorts() {
         ArrayList<OFPort> ports = new ArrayList<>();
@@ -105,9 +110,11 @@ public class OFPortBitMap512 extends Masked<OFBitMask512> {
 
         }
 
-        /** @return whether or not the given port is logically included in the
-         *  match, i.e., whether a packet from in-port <em>port</em> be matched by
-         *  this OXM.
+        /**
+         * @param port the port to check
+         * @return whether or not the given port is logically included in the
+         * match, i.e., whether a packet from in-port <em>port</em> be matched by
+         * this OXM.
          */
         public boolean isOn(OFPort port) {
             // see the implementation note above about the logical inversion of the mask
@@ -115,8 +122,11 @@ public class OFPortBitMap512 extends Masked<OFBitMask512> {
                     raw5, raw6, raw7, raw8, port.getPortNumber()));
         }
 
-        /** remove this port from the match, i.e., packets from this in-port
-         *  will NOT be matched.
+        /** 
+         * remove this port from the match, i.e., packets from this in-port
+         * will NOT be matched.
+         * @param port the port the remove from the match
+         * @return this mutator
          */
         public Builder unset(OFPort port) {
             // see the implementation note above about the logical inversion of the mask
@@ -149,8 +159,11 @@ public class OFPortBitMap512 extends Masked<OFBitMask512> {
             return this;
         }
 
-        /** add this port from the match, i.e., packets from this in-port
-         *  will NOT be matched.
+        /**
+         * add this port from the match, i.e., packets from this in-port
+         * will be matched.
+         * @param port the port to add to the match
+         * @return this mutator
          */
         public Builder set(OFPort port) {
             // see the implementation note above about the logical inversion of the mask

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/HexString.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/HexString.java
@@ -4,7 +4,7 @@ import io.netty.util.internal.EmptyArrays;
 
 /** Utility method to convert hexadecimal string from/to longs and byte arrays.
  *
- * @author Andreas Wundsam <andreas.wundsam@bigswitch.com>
+ * @author Andreas Wundsam {@literal <}andreas.wundsam@bigswitch.com{@literal >}
  */
 public final class HexString {
 
@@ -26,7 +26,7 @@ public final class HexString {
     /**
      * Convert a string of bytes to a ':' separated hex string
      *
-     * @param bytes
+     * @param bytes the byte[] to convert
      * @return "0f:ca:fe:de:ad:be:ef"
      */
     public static String toHexString(final byte[] bytes) {
@@ -77,8 +77,10 @@ public final class HexString {
 
     /** Deprecated version of {@link #toBytes(String)}.
      *
-     * @throws NumberFormatException
-     * @{@link Deprecated} because of inconsistent naming
+     * @throws NumberFormatException upon values parse error
+     * @param values the hexstring to parse into a byte[]
+     * @return a byte[] representing the hexstring
+     * {@link Deprecated} because of inconsistent naming
      */
     @Deprecated
     public static byte[] fromHexString(final String values) throws NumberFormatException {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/MultiplePktInReasonUtil.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/MultiplePktInReasonUtil.java
@@ -20,7 +20,10 @@ public class MultiplePktInReasonUtil {
     /**
      * This function is used in BVS T5/6 to decode the multiple packet in
      * reasons in Match.MetaData field.
-     * */
+     *
+     * @param pktIn the packet in message
+     * @return the set of packet in reasons
+     */
     public static Set<OFBsnPktinFlag> getOFBsnPktinFlags(OFPacketIn pktIn) {
         if(pktIn.getVersion().compareTo(OFVersion.OF_13) < 0) {
             throw new IllegalArgumentException("multiple pkt in reasons are "

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/PrimitiveSinkUtils.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/PrimitiveSinkUtils.java
@@ -48,8 +48,8 @@ public class PrimitiveSinkUtils {
     /** puts the elements of a sorted set into the {@link PrimitiveSink}. Does not support null
      *  elements. The elements are assumed to be self-delimitating.
      *
-     * @param sink
-     * @param set
+     * @param sink the sink to put the sorted set
+     * @param set the sorted set
      */
     public static void putSortedSetTo(PrimitiveSink sink,
             SortedSet<? extends PrimitiveSinkable> set) {
@@ -62,13 +62,13 @@ public class PrimitiveSinkUtils {
     /** puts the elements of a list into the {@link PrimitiveSink}. Does not support null
      *  elements. The elements are assumed to be self-delimitating.
      *
-     * @param sink
-     * @param set
+     * @param sink the sink to put the list elements
+     * @param list the list
      */
     public static void putListTo(PrimitiveSink sink,
-            List<? extends PrimitiveSinkable> set) {
-        sink.putInt(set.size());
-        for(PrimitiveSinkable e: set) {
+            List<? extends PrimitiveSinkable> list) {
+        sink.putInt(list.size());
+        for(PrimitiveSinkable e: list) {
             e.putTo(sink);
         }
     }


### PR DESCRIPTION
Reviewer: @andi-bigswitch @rlane 

Clean up Javadoc. The Javadoc part of the build (make package-java) fails with Oracle JDK 1.8 due to warnings, which should probably be interpreted by the maven Javadoc plugin as warnings (and not errors). Nevertheless, the warnings have been fixed now by adding missing Javadoc annotations and correcting incomplete annotations.

Also, fix copy-and-paste errors:
(1) OFPortBitmask and OFPortBitmask512 set()/unset() functions had the same Javadoc comments
(2) PrimitiveSinkUtils putListTo() used 'set' variable name for a List, probably pasted from putSortedListTo() above it.