### PR TITLE
Add equalsIgnoreXid() + hashCodeIgnoreXid() to OFMessage

### DIFF
--- a/java_gen/templates/custom/interface/OFMessage.java
+++ b/java_gen/templates/custom/interface/OFMessage.java
@@ -1,0 +1,9 @@
+    // Additional methods
+    
+    /**
+     * Compares the two messages for equality, ignoring the XID field.
+     *
+     * @param obj the other message to compare
+     * @return true if the messages are equal, ignoring the XID; false otherwise
+     */
+    boolean equalsIgnoreXid(Object obj);

--- a/java_gen/templates/custom/interface/OFMessage.java
+++ b/java_gen/templates/custom/interface/OFMessage.java
@@ -9,6 +9,19 @@
 
     /**
      * Computes the hashcode of the message, ignoring the XID field.
+     * This can be useful in hashing OFMessages where an OFMessage
+     * is "the same as" another OFMessage if all fields are equal
+     * except for possibly the XIDs, which may or may not be equal.
+     *
+     * The obvious problem is that existing hash data structure 
+     * implementations will use OFMessage's hashCode() function instead.
+     * In order to use the functionality of hashCodeIgnoreXid(), one 
+     * must wrap the OFMessage within a user-defined class, where this 
+     * user-defined class is used as the key within a hash data structure, 
+     * e.g. HashMap. The user-defined class' overrideen hashCode() 
+     * function must explicitly invoke hashCodeIgnoreXid() when computing 
+     * the hash of the OFMessage member instead of computing it using 
+     * OFMessage's hashCode().
      *
      * @return the hashcode of the message, ignoring the XID
      */

--- a/java_gen/templates/custom/interface/OFMessage.java
+++ b/java_gen/templates/custom/interface/OFMessage.java
@@ -1,4 +1,3 @@
-    // Additional methods
     
     /**
      * Compares the two messages for equality, ignoring the XID field.

--- a/java_gen/templates/custom/interface/OFMessage.java
+++ b/java_gen/templates/custom/interface/OFMessage.java
@@ -6,3 +6,10 @@
      * @return true if the messages are equal, ignoring the XID; false otherwise
      */
     boolean equalsIgnoreXid(Object obj);
+
+    /**
+     * Computes the hashcode of the message, ignoring the XID field.
+     *
+     * @return the hashcode of the message, ignoring the XID
+     */
+    int hashCodeIgnoreXid();

--- a/java_gen/templates/of_class.java
+++ b/java_gen/templates/of_class.java
@@ -420,6 +420,7 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
     }
 
     //:: if filter(lambda m: m.name == 'xid', msg.data_members):
+    @Override
     public boolean equalsIgnoreXid(Object obj) {
         if (this == obj)
             return true;
@@ -475,4 +476,31 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
         return result;
     }
 
+    //:: if filter(lambda m: m.name == 'xid', msg.data_members):
+    @Override
+    public int hashCodeIgnoreXid() {
+        //:: if len(msg.data_members) > 0:
+        final int prime = 31;
+        //:: #endif
+        int result = 1;
+
+        //:: for prop in msg.data_members:
+        //:: if prop.java_type.is_primitive and prop.name == 'xid':
+        // ignore XID
+        //:: elif prop.java_type.pub_type == 'long':
+        result = prime *  (int) (${prop.name} ^ (${prop.name} >>> 32));
+        //:: elif prop.java_type.pub_type == 'boolean':
+        result = prime * result + (${prop.name} ? 1231 : 1237);
+        //:: elif prop.java_type.is_primitive:
+        result = prime * result + ${prop.name};
+        //:: elif prop.java_type.is_array:
+        result = prime * result + Arrays.hashCode(${prop.name});
+        //:: else:
+        result = prime * result + ((${prop.name} == null) ? 0 : ${prop.name}.hashCode());
+        //:: #endif
+        //:: #endfor
+        return result;
+    }
+
+    //:: #endif
 }

--- a/java_gen/templates/of_interface.java
+++ b/java_gen/templates/of_interface.java
@@ -43,7 +43,6 @@ public interface ${msg.name}${ "<%s>" % msg.type_annotation if msg.type_annotati
 //:: if os.path.exists("%s/custom/interface/%s.java" % (template_dir, msg.name)):
 //:: include("custom/interface/%s.java" % msg.name, msg=msg)
 //:: #endif
-    
 
     void writeTo(ByteBuf channelBuffer);
 


### PR DESCRIPTION
Reviewer: @andi-bigswitch 

Otherwise, we have to cast to the specific implementing class to access the function. The assumption is that all implementers of OFMessage will have an equalsIgnoreXid() function generated for them, which they should and do.

Also, removed extra space from of_interface.java.

And lastly, introduce hashCodeIgnoreXid() for OFMessage and its implementing classes. This will allow us to hash an OFMessage disregarding the XID such that two or more OFMessages that are equal except for the XID field will produce the same hash.