### PR TITLE
Added Nicira (OpenVSwitch) exit, resubmit, and resubmit_table actions.

### DIFF
--- a/openflow_input/nicira_exit
+++ b/openflow_input/nicira_exit
@@ -1,0 +1,16 @@
+#version any
+
+// Nicira (OpenVSwitch) Exit action.
+//
+// Causes the datapath to immediately halt execution of further apply-actions.
+//
+// See ovs-ofctl man page for details:
+//    http://openvswitch.org/support/dist-docs/ovs-ofctl.8.txt
+struct of_action_nicira_exit : of_action_nicira {
+    uint16_t type == 65535;
+    uint16_t len;
+    uint32_t experimenter == 0x2320;
+    uint16_t subtype == 0x11;
+    pad(2);
+    pad(4);
+};

--- a/openflow_input/nicira_resubmit
+++ b/openflow_input/nicira_resubmit
@@ -1,0 +1,19 @@
+#version any
+
+// Nicira (OpenVSwitch) Resubmit action.
+//
+// Re-searches this OpenFlow flow table with the in_port field
+// replaced by port (if port is not OFPP_IN_PORT) and executes the
+// actions found, if any, in addition to any other actions in this
+// flow entry.
+//
+// See ovs-ofctl man page for details:
+//    http://openvswitch.org/support/dist-docs/ovs-ofctl.8.txt
+struct of_action_nicira_resubmit : of_action_nicira {
+    uint16_t type == 65535;
+    uint16_t len;
+    uint32_t experimenter == 0x2320;
+    uint16_t subtype == 0x1;
+    uint16_t port; // 16-bit port number for all OF versions, default should be OFPP_IN_PORT
+    pad(4);
+};

--- a/openflow_input/nicira_resubmit_table
+++ b/openflow_input/nicira_resubmit_table
@@ -1,0 +1,20 @@
+#version any
+
+// Nicira (OpenVSwitch) Resubmit action with table id.
+//
+// Searches the specified OpenFlow flow table with the in_port field
+// replaced by port (if port is not OFPP_IN_PORT) and executes the
+// actions found, if any, in addition to any other actions in this
+// flow entry.
+//
+// See ovs-ofctl man page for details:
+//    http://openvswitch.org/support/dist-docs/ovs-ofctl.8.txt
+struct of_action_nicira_resubmit_table : of_action_nicira {
+    uint16_t type == 65535;
+    uint16_t len;
+    uint32_t experimenter == 0x2320;
+    uint16_t subtype == 0xe;
+    uint16_t port; // 16-bit port number for all OF versions, default should be OFPP_IN_PORT
+    uint8_t table_id; // OFPTT_ALL means "same table as this flow"
+    pad(3);
+};


### PR DESCRIPTION
Tested with Floodlight master branch HEAD (7f62a18c1c1cd10c33532180b1d9c577213bd3c0) and OpenVSwitch 2.4.1.

Note that `of_action_nicira_resubmit` and `of_action_nicira_resubmit_table` take a 16-bit OFPort for all OpenFlow protocol versions.  The `port` field would ideally default to OFPort.IN_PORT if behavior is to match that of `ovs-ofctl`.

Not sure how reviewer is chosen for this project.  Please let me know what follow-up is needed.