### PR TITLE
New TLV types for static flag and checksum for NDP

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -861,3 +861,13 @@ struct of_bsn_tlv_ndp_offload : of_bsn_tlv {
     uint16_t length;
 };
 
+struct of_bsn_tlv_ndp_static : of_bsn_tlv {
+    uint16_t type == 124;
+    uint16_t length;
+};
+
+struct of_bsn_tlv_icmpv6_chksum : of_bsn_tlv {
+    uint16_t type == 125;
+    uint16_t length;
+    uint16_t value;
+};


### PR DESCRIPTION
Reviewer: @rlane 

Added TLV types for:
- Static flag to identify static endpoints in neighbor table
- icmpv6 checksum for the external router table to identify any change