### PR TITLE
Add egress_only tlv

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -940,3 +940,8 @@ struct of_bsn_tlv_l3_dst_class_id : of_bsn_tlv {
     uint16_t length;
     uint32_t value;
 };
+
+struct of_bsn_tlv_egress_only : of_bsn_tlv {
+    uint16_t type == 137;
+    uint16_t length;
+};


### PR DESCRIPTION
Reviewer: @poolakiran 
cc @meiyangbigswitch 

This tlv will be used in vxlan_access_vp table to indicate creation of a vxlan access virtual port for egress purpose only(for RioT decap case) and this will make the switch avoid installing a Vlan_xlate entry for the access virtual port.