### PR TITLE
Fix IPv6Address.toString to conform to RFC 5952 standard canonical string rep

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.projectfloodlight</groupId>
     <artifactId>openflowj</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>OpenFlowJ-Loxi</name>

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
@@ -578,7 +578,7 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
                 if (getUnsignedShortWord(i) != 0) {
                     // end of this candidate word
                     int candidateLength = i - candidateStart;
-                    if (candidateLength >= maxLength) {
+                    if ((candidateLength > 1) && (candidateLength > maxLength)) {
                         start = candidateStart;
                         maxLength = candidateLength;
                     }
@@ -594,7 +594,7 @@ public class IPv6Address extends IPAddress<IPv6Address> implements Writeable {
 
         if (candidateStart >= 0) {
             int candidateLength = 8 - candidateStart;
-            if (candidateLength >= maxLength) {
+            if ((candidateLength > 1) && (candidateLength > maxLength)) {
                 start = candidateStart;
                 maxLength = candidateLength;
             }

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPv6AddressTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPv6AddressTest.java
@@ -321,6 +321,13 @@ public class IPv6AddressTest {
         assertEquals("0000:0000:0000:0000:0000:0000:0000:0000", IPv6Address.of("::").toString(false, true));
         assertEquals("1::4:5:6:0:8", IPv6Address.of("1:0:0:4:5:6:0:8").toString(true, false));
         assertEquals("1:0:0:4::8", IPv6Address.of("1:0:0:4:0:0:0:8").toString(true, false));
+        // Two equal length zero runs; should zero compress the first instance
+        assertEquals("1::4:2:0:0:8", IPv6Address.of("1:0:0:4:2:0:0:8").toString(true, false));
+        // Shouldn't zero compress a single zero
+        assertEquals("1:0:2:4:3:1:0:8", IPv6Address.of("1:0:2:4:3:1:0:8").toString(true, false));
+        // Test zero runs at the end of the address since that's a different code path in toString
+        assertEquals("1::4:2:8:0:0", IPv6Address.of("1:0:0:4:2:8:0:0").toString(true, false));
+        assertEquals("1:3:2:4:3:1:5:0", IPv6Address.of("1:3:2:4:3:1:5:0").toString(true, false));
     }
 
     @Test


### PR DESCRIPTION
Reviewer: @andi-bigswitch

- if there are multiple equal length zero runs zero compress the first one, not the last one
- don't zero compress a single zero