### PR TITLE
java/pom.xml: bump version to 3.2.0-SNAPSHOT for new dev cycle

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.projectfloodlight</groupId>
     <artifactId>openflowj</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>OpenFlowJ-Loxi</name>


### PR DESCRIPTION
Reviewer: @Sovietaced 

Bumping OpenFlowJ version for the new dev cycle...