### PR TITLE
SWL-3685: Add new TLV types for router_ip table and prefix table flag

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1044,3 +1044,13 @@ struct of_bsn_tlv_loopback_mode : of_bsn_tlv {
     uint16_t length;
     enum ofp_bsn_loopback_mode value;
 };
+
+struct of_bsn_tlv_no_arp_response : of_bsn_tlv {
+    uint16_t type == 147;
+    uint16_t length;
+};
+
+struct of_bsn_tlv_no_ns_response : of_bsn_tlv {
+    uint16_t type == 148;
+    uint16_t length;
+};


### PR DESCRIPTION
Reviewer: @poolakiran 

-Add new TLV types for router_ip_table flag no_arp_response
-Add new TLV type for prefix table (IPv6) flag no_ns_response