### PR TITLE
[SWL-3678] Add a new line to trigger to update loxigen-artifacts

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1071,3 +1071,4 @@ struct of_bsn_tlv_optics_always_enabled : of_bsn_tlv {
     uint16_t type == 150;
     uint16_t length;
 };
+


### PR DESCRIPTION
Reviewer: @andi-bigswitch 
CC @kenchiang 

* Added a new blank line to trigger to update the loxigen-artifacts

This is to trigger a loxigen-artifacts update after #544, which was greenbuttoned. `Loxigen-artifacts` is updated at the end of the abat automerge process, so we didn't see an update for #544. 