### PR TITLE
[SWL-3678] Add a new TLV force_link_up for port_config gentable

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1071,3 +1071,8 @@ struct of_bsn_tlv_optics_always_enabled : of_bsn_tlv {
     uint16_t type == 150;
     uint16_t length;
 };
+
+struct of_bsn_tlv_force_link_up : of_bsn_tlv {
+    uint16_t type == 151;
+    uint16_t length;
+};


### PR DESCRIPTION
Reviewer: @wilmo119 
CC: @shudongz @jnealtowns @andi-bigswitch 

* Add a new TLV **_force_link_up_** port property for future use as Shudong has suggested
* Passed unit test on DUT z9100-1