### PR TITLE
Add TLVs: REST server, URI scheme, and record packets

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1076,3 +1076,22 @@ struct of_bsn_tlv_force_link_up : of_bsn_tlv {
     uint16_t type == 151;
     uint16_t length;
 };
+
+struct of_bsn_tlv_rest_server : of_bsn_tlv {
+    uint16_t type == 152;
+    uint16_t length;
+};
+
+struct of_bsn_tlv_uri_scheme : of_bsn_tlv {
+    uint16_t type == 153;
+    uint16_t length;
+    of_octets_t value;
+};
+
+/* Type 154 used (TODO) */
+
+struct of_bsn_tlv_record_packets : of_bsn_tlv {
+    uint16_t type == 155;
+    uint16_t length;
+    uint8_t value;
+};

--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1097,5 +1097,5 @@ struct of_bsn_tlv_timestamp : of_bsn_tlv {
 struct of_bsn_tlv_record_packets : of_bsn_tlv {
     uint16_t type == 155;
     uint16_t length;
-    uint8_t value;
+    uint32_t value;
 };


### PR DESCRIPTION
Reviewer: @wilmo119 @kenchiang 

I'm including a uint8_t for record_packets even though it's just a boolean... just in case we support more than on/off in the future.