### PR TITLE
Bugfix: removing duplicate of_flow_stats_request

### DIFF
--- a/java_gen/java_type.py
+++ b/java_gen/java_type.py
@@ -820,7 +820,6 @@ exceptions = {
         'of_features_reply' : { 'auxiliary_id' : of_aux_id},
 
         'of_bundle_add_msg' : { 'data' : of_message },
-        'of_flow_stats_request' : { 'out_group' : of_group },
         'of_flow_lightweight_stats_request' : { 'out_group' : of_group }
 }
 


### PR DESCRIPTION
of_flow_stats_request has special default value (see comment on L537) 
and definition with special definition is already present at L790.

This patch removes duplicate definition of of_flow_stats_request.