### PR TITLE
Support for IPv6 tunnel (supported from Open vSwitch 2.6.0)

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -222,6 +222,14 @@ public class MatchField<F extends OFValueType<F>> {
             new MatchField<IPv4Address>("tunnel_ipv4_dst", MatchFields.TUNNEL_IPV4_DST,
                     new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4));
 
+    public final static MatchField<IPv6Address> TUNNEL_IPV6_SRC =
+            new MatchField<IPv6Address>("tunnel_ipv6_src", MatchFields.TUNNEL_IPV6_SRC,
+                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+
+    public final static MatchField<IPv6Address> TUNNEL_IPV6_DST =
+            new MatchField<IPv6Address>("tunnel_ipv6_dst", MatchFields.TUNNEL_IPV6_DST,
+                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+
     public final static MatchField<OFBitMask128> BSN_IN_PORTS_128 =
             new MatchField<OFBitMask128>("bsn_in_ports_128", MatchFields.BSN_IN_PORTS_128);
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchFields.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchFields.java
@@ -49,6 +49,8 @@ public enum MatchFields {
     ACTSET_OUTPUT,
     TUNNEL_IPV4_SRC,
     TUNNEL_IPV4_DST,
+    TUNNEL_IPV6_SRC,
+    TUNNEL_IPV6_DST,
     BSN_IN_PORTS_128,
     BSN_IN_PORTS_512,
     BSN_LAG_ID,

--- a/openflow_input/oxm_nicira_tun
+++ b/openflow_input/oxm_nicira_tun
@@ -53,3 +53,9 @@ struct of_oxm_tunnel_ipv4_dst_masked : of_oxm {
     of_ipv4_t value;
     of_ipv4_t value_mask;
 };
+
+// Nicira extension for tun_ipv6_dst
+struct of_oxm_tunnel_ipv6_dst : of_oxm {
+    uint32_t type_len == 0x0001dc10;
+    of_ipv6_t value;
+};


### PR DESCRIPTION
Support for IPv6 tunnel (supported from Open vSwitch 2.6.0). Needed for handling VXLAN IPv6 tunnel in ONOS. There you can find some discussion:
https://gerrit.onosproject.org/#/c/12961/
