### PR TITLE
OXS: fix bit lengths of various value fields

### DIFF
--- a/openflow_input/oxs-1.5
+++ b/openflow_input/oxs-1.5
@@ -7,25 +7,25 @@ struct of_oxs {
 
 struct of_oxs_duration : of_oxs {
     uint32_t type_len == 0x80020008 ;
-    uint16_t value;
+    uint64_t value;
 };
 
 struct of_oxs_idle_time : of_oxs {
     uint32_t type_len == 0x80020208 ;
-    uint16_t value;
+    uint64_t value;
 };
 
 struct of_oxs_flow_count : of_oxs {
     uint32_t type_len == 0x80020404 ;
-    uint16_t value;
+    uint32_t value;
 };
 
 struct of_oxs_packet_count : of_oxs {
     uint32_t type_len == 0x80020608 ;
-    uint16_t value;
+    uint64_t value;
 };
 
 struct of_oxs_byte_count : of_oxs {
     uint32_t type_len == 0x80020808 ;
-    uint16_t value;
+    uint64_t value;
 };


### PR DESCRIPTION
According to spec 1.5,  value bits for oxs stat fields should not be 16. This information is written in Flow Stat Fields . Page 86