### PR TITLE
SWLVX-30: reverting the addition of TLV for digest algorithm

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1158,14 +1158,3 @@ struct of_bsn_tlv_routing_param : of_bsn_tlv {
     uint16_t length;
     enum ofp_bsn_routing_param value;
 };
-
-enum of_bsn_digest_alg(wire_type=uint8_t) {
-    OF_BSN_DIGEST_ALG_MD5 = 1,
-    OF_BSN_DIGEST_ALG_SHA256 = 2,
-};
-
-struct of_bsn_tlv_digest_alg : of_bsn_tlv {
-    uint16_t type == 162;
-    uint16_t length;
-    enum of_bsn_digest_alg value;
-};


### PR DESCRIPTION
This is just to revert a change done recently regarding addition of a tlv for digest algorithm. It's not needed anymore.

Reviewer: trivial
CC: @poolakiran 