### PR TITLE
[SWL-4374] Changed the FEC config enum type to uint32_t

### DIFF
--- a/openflow_input/bsn_forward_error_correction
+++ b/openflow_input/bsn_forward_error_correction
@@ -28,7 +28,7 @@
 #version 5
 #version 6
 
-enum ofp_bsn_fec_config_state(wire_type=uint16_t) {
+enum ofp_bsn_fec_config_state(wire_type=uint32_t) {
     OFP_BSN_FEC_CONFIG_STATE_UNSET = 0,
     OFP_BSN_FEC_CONFIG_STATE_ENABLED = 1,
     OFP_BSN_FEC_CONFIG_STATE_DISABLED = 2,


### PR DESCRIPTION
Reviewer: @kenchiang 

* Changed the FEC config enum type to unit32_t in order to maintain the FEC struct size unchanged.