### PR TITLE
don't fail pushartifacts if the artifact repo already has the commit

### DIFF
--- a/.build/push-artifacts.sh
+++ b/.build/push-artifacts.sh
@@ -51,21 +51,29 @@ fi
     set -xe
     cd $ARTIFACT_REPO
     echo $last_loxi_log >loxi-revision
-    git add -A
 
-    (
-       echo "Artifacts from ${loxi_github_url} (Branch ${loxi_branch})"
-       echo
-       echo "Loxigen Head commit floodlight/loxigen@${loxi_head}"
-       cat $git_log_file
-    ) | git commit --file=-
+    if ! git diff-index --quiet HEAD --; then
+        # if changes in the working dir
+        git add -A
 
-    git tag -a -f "loxi/${loxi_head}" -m "Tag Loxigen Revision ${loxi_head}"
-    git push --tags -f
-    if [[ $ARTIFACT_TARGET_BRANCH != $ARTIFACT_REPO_BRANCH ]]; then
-        git push -f origin HEAD:${ARTIFACT_TARGET_BRANCH}
+        (
+        echo "Artifacts from ${loxi_github_url} (Branch ${loxi_branch})"
+        echo
+        echo "Loxigen Head commit floodlight/loxigen@${loxi_head}"
+        cat $git_log_file
+        ) | git commit --file=-
+
+        git tag -a -f "loxi/${loxi_head}" -m "Tag Loxigen Revision ${loxi_head}"
+        git push --tags -f
+        if [[ $ARTIFACT_TARGET_BRANCH != $ARTIFACT_REPO_BRANCH ]]; then
+            git push -f origin HEAD:${ARTIFACT_TARGET_BRANCH}
+        else
+            git push origin HEAD
+        fi
     else
-        git push origin HEAD
+        echo "No changes in the working dir."
+        echo "Branch $ARTIFACT_TARGET_BRANCH already seems to have the latest from loxi branch ${loxi_branch}"
+        echo "Loxigen head commit ${loxi_head}"
     fi
 )
 


### PR DESCRIPTION
Reviewer: @ronaldchl 

.abat-automerge is currently still pushing artifacts, just as master is. This failed master build #2 here:
https://jenkins.bigswitch.com/view/Loxigen/job/floodlight%20Organization/job/loxigen/job/master/2/

I will remove the push artifacts from abat-automerge, but master builds should obviously not fail if you build the same commit twice in a row.