### PR TITLE
Jenkinsfile

### DIFF
--- a/.build/push-artifacts.sh
+++ b/.build/push-artifacts.sh
@@ -52,7 +52,7 @@ fi
     cd $ARTIFACT_REPO
     echo $last_loxi_log >loxi-revision
 
-    if ! git diff-index HEAD --; then
+    if ! git diff-index --exit-code HEAD --; then
         # if changes in the working dir
         git status
         git add -A

--- a/Makefile
+++ b/Makefile
@@ -91,16 +91,16 @@ eclipse-workspace:
 	cd ${OPENFLOWJ_ECLIPSE_WORKSPACE} && perl -pi -e 's{<classpathentry kind="src" path="[^"]*/java_gen/pre-written/src/}{<classpathentry kind="src" path="src/}' .classpath
 
 check-java: java
-	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn compile test-compile test
+	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn --batch-mode compile test-compile test
 
 package-java: java
-	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn package
+	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn --batch-mode package
 
 deploy-java: java
-	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn deploy
+	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn --batch-mode deploy
 
 install-java: java
-	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn install
+	cd ${OPENFLOWJ_OUTPUT_DIR} && mvn --batch-mode install
 
 wireshark: .loxi_ts.wireshark
 

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -267,6 +267,9 @@ i                                  <ciNodeName>${env.NODE_NAME}</ciNodeName>
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <quiet>true</quiet>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Reviewer: @ronaldchl 
CC: @poolakiran 

This should unbrick  the generation of `loxigen-artifacts` (`77f31a9`). The issue there was I removed the `--quiet` parameter earlier for debugging; turns out removing the `--quiet` parameter *also* changes the exit code behavior, unless you specify `--exit-code` explicitly.

Otherwise, a couple of flags to reduce the size of the build console logs.