### PR TITLE
push-artifacts: add to index first and then compare to index for changes

### DIFF
--- a/.build/push-artifacts.sh
+++ b/.build/push-artifacts.sh
@@ -52,11 +52,11 @@ fi
     cd $ARTIFACT_REPO
     echo $last_loxi_log >loxi-revision
 
-    if ! git diff-index --exit-code HEAD --; then
-        # if changes in the working dir
-        git status
-        git add -A
+    # if changes in the working dir
+    git status
+    git add -A
 
+    if ! git diff-index --cached --exit-code HEAD --; then
         (
         echo "Artifacts from ${loxi_github_url} (Branch ${loxi_branch})"
         echo


### PR DESCRIPTION
Reviewer: @ronaldchl 

Another attempt at getting the Jenkinsfile-based master build to be green (and actually work). The previous strategy with `git diff-index` to try to detect workdir changes did not work; apparently `diff-index` gets thrown off by the change in timestamps and doesn't actually check the diff.

The new strategy is to always do `git add -A` to add any changed files to the index (this _does_ check the digest) and then use `git diff-index --cached` to check the index for changes.
