### PR TITLE
abat-automerge: remove push-artifacts

### DIFF
--- a/.abat-automerge
+++ b/.abat-automerge
@@ -4,7 +4,3 @@ cd "$ROOTDIR"
 
 ln -sf ../../.hooks/pre-commit .git/hooks/pre-commit
 make all check-all
-
-if [[ ${ARTIFACT_REPO_URL-} ]]; then
-    ./.build/push-artifacts.sh ${ARTIFACT_REPO_URL}
-fi


### PR DESCRIPTION
Reviewer: trivial
CC: @ronaldchl 

push-artifacts is now done by the master build (Jenkinsfile)
