### PR TITLE
BSC-11527: sign build maven artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
                         mvn --batch-mode -s $MAVEN_SETTINGS -Prelease -Psign -Drevision=${mavenPatchVersion} package deploy
                     """
                 }
-                sh """ gpg --delete-secret-key build-admins@bigswitch.com """
+                sh """ gpg --batch --delete-secret-key 'EF31 1B74 EE63 3982 2335  F1B2 68B8 8023 E9F9 33D3' """
             }
         }
     }

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -274,6 +274,26 @@ i                                  <ciNodeName>${env.NODE_NAME}</ciNodeName>
                 </plugins>
             </build>
         </profile>
-  </profiles>
-
+        <profile>
+            <id>sign</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Reviewer: @ronaldchl 

This PR makes the Maven Artifacts that we upload to the Sonatype OSS repository GPG-signed. this is necessary so that we can publish "proper" release versions (as opposed to snapshots).