### PR TITLE
Extend ofp_bsn_routing_param enum with IPv6 values

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1159,6 +1159,9 @@ enum ofp_bsn_routing_param(wire_type=uint16_t) {
     OFP_BSN_ROUTING_PARAM_OSPF_UCAST = 1,
     OFP_BSN_ROUTING_PARAM_OSPF_MCAST = 2,
     OFP_BSN_ROUTING_PARAM_ARP_FRR = 3,
+    OFP_BSN_ROUTING_PARAM_IPV6_OSPF_UCAST = 4,
+    OFP_BSN_ROUTING_PARAM_IPV6_OSPF_MCAST = 5,
+    OFP_BSN_ROUTING_PARAM_IPV6_NDP_FRR = 6,
 };
 
 struct of_bsn_tlv_routing_param : of_bsn_tlv {


### PR DESCRIPTION
Reviewer: @poolakiran 
CC: @chichong-bsn