### PR TITLE
Padding missing in loci of_action_set_field

### DIFF
--- a/test_data/of13/action_set_field__tcp_src.data
+++ b/test_data/of13/action_set_field__tcp_src.data
@@ -9,3 +9,11 @@ ofp.action.set_field(field=ofp.oxm.tcp_src(50))
 -- java
 OFOxms oxms = OFFactories.getFactory(OFVersion.OF_13).oxms();
 builder.setField(oxms.tcpSrc(TransportPort.of(50)))
+-- c
+obj = of_action_set_field_new(OF_VERSION_1_3);
+
+of_object_t *oxm = of_oxm_tcp_src_new(OF_VERSION_1_3);
+of_oxm_tcp_src_value_set(oxm, 50);
+
+of_action_set_field_field_set(obj, oxm);
+of_object_delete(oxm);


### PR DESCRIPTION
CC: @andi-bigswitch 

Hey @kenchiang and @wilmo119, When building a OF 1.3 `of_action_set_field`, loci appears to not correctly add padding to 16 bytes:

```
test of13_action_set_field__tcp_src:  FAIL

--- Expected: (len=16)
00: 00 19 00 10 80 00 1a 02 
08: 00 32 00 00 00 00 00 00 

--- Actual: (len=10)
00: 00 19 00 0a 80 00 1a 02 
08: 00 32 
```

Could you comment if this is behavior is a bug in loci or am I not using the API correctly here?