### PR TITLE
Correct format for OF1.3 of_async_get_request.

### DIFF
--- a/openflow_input/standard-1.3
+++ b/openflow_input/standard-1.3
@@ -2085,12 +2085,6 @@ struct of_async_get_request : of_header {
     uint8_t type == 26;
     uint16_t length;
     uint32_t xid;
-    uint32_t packet_in_mask_equal_master;
-    uint32_t packet_in_mask_slave;
-    uint32_t port_status_mask_equal_master;
-    uint32_t port_status_mask_slave;
-    uint32_t flow_removed_mask_equal_master;
-    uint32_t flow_removed_mask_slave;
 };
 
 struct of_async_get_reply : of_header {


### PR DESCRIPTION
This request has no body.  As OpenFlow 1.3 section 7.3.10 "Set Asynchronous
Configuration Message" says:

    There is no body for OFPT_GET_ASYNC_REQUEST beyond the OpenFlow header.