### PR TITLE
[BCF-4.7.x] LOXI-81 LOXI-82: TransportPort - treat 0xFFFF as "NO_MASK"

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/TransportPort.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/TransportPort.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Ints;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Represents L4 (Transport Layer) port (TCP, UDP, etc.)
@@ -20,7 +21,7 @@ public class TransportPort implements OFValueType<TransportPort> {
     private final static int NONE_VAL = 0;
     public final static TransportPort NONE = new TransportPort(NONE_VAL);
 
-    public static final TransportPort NO_MASK = new TransportPort(0xFFFFFFFF);
+    public static final TransportPort NO_MASK = new TransportPort(MAX_PORT);
     public static final TransportPort FULL_MASK = TransportPort.of(0x0);
 
     private final int port;
@@ -30,12 +31,13 @@ public class TransportPort implements OFValueType<TransportPort> {
     }
 
     public static TransportPort of(int port) {
-        if(port == NONE_VAL)
+        if (port == NONE_VAL)
             return NONE;
-        else if (port == NO_MASK.port)
+        else if ((port & NO_MASK.port) == NO_MASK.port)
             return NO_MASK;
         else if (port < MIN_PORT || port > MAX_PORT) {
-            throw new IllegalArgumentException("Illegal transport layer port number: " + port);
+            throw new IllegalArgumentException(
+                    "Illegal transport layer port number: " + port);
         }
         return new TransportPort(port);
     }
@@ -53,7 +55,7 @@ public class TransportPort implements OFValueType<TransportPort> {
     public boolean equals(Object obj) {
         if (!(obj instanceof TransportPort))
             return false;
-        TransportPort other = (TransportPort)obj;
+        TransportPort other = (TransportPort) obj;
         if (other.port != this.port)
             return false;
         return true;
@@ -87,7 +89,7 @@ public class TransportPort implements OFValueType<TransportPort> {
 
     @Override
     public int compareTo(TransportPort o) {
-        return Ints.compare(port,  o.port);
+        return Ints.compare(port, o.port);
     }
 
     @Override

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/TransportPortTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/TransportPortTest.java
@@ -1,0 +1,80 @@
+package org.projectfloodlight.openflow.types;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+public class TransportPortTest {
+
+    @Test
+    public void testOf() {
+        assertThat(TransportPort.of(1).getPort(), equalTo(1));
+        assertThat(TransportPort.of(2).getPort(), equalTo(2));
+        assertThat(TransportPort.of(0xffee).getPort(), equalTo(0xffee));
+        assertThat(TransportPort.of(0).getPort(), equalTo(0));
+        assertThat(TransportPort.of(0), equalTo(TransportPort.FULL_MASK));
+        assertThat(TransportPort.of(0xFFFF), equalTo(TransportPort.NO_MASK));
+        // -1 (0xFFFF_FFFF) gets normalized to NO_MASK
+        assertThat(TransportPort.of(-1), equalTo(TransportPort.NO_MASK));
+    }
+
+    @Test
+    public void testEquals() {
+        assertThat(TransportPort.of(1), equalTo(TransportPort.of(1)));
+        assertThat(TransportPort.of(1), not(equalTo(TransportPort.of(2))));
+        assertThat(TransportPort.of(2).getPort(), equalTo(2));
+        assertThat(TransportPort.FULL_MASK, not(equalTo(TransportPort.NO_MASK)));
+
+        assertThat(TransportPort.of(1).hashCode(), equalTo(TransportPort.of(1).hashCode()));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOfInvalidNegative() {
+        TransportPort.of(-2);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOfInvalidTooHigh() {
+        TransportPort.of(1 << 16);
+    }
+
+    @Test
+    public void testReadWriteTwoBytes() throws Exception {
+        readWriteTwoBytes(1, 0x00, 0x01);
+        readWriteTwoBytes(0xFF, 0x00, 0xFF);
+        readWriteTwoBytes(0xFFFE, 0xFF, 0xFE);
+        readWriteTwoBytes(0xFFFF, 0xFF, 0xFF);
+        readWriteTwoBytes(-1, 0xFF, 0xFF);
+    }
+
+     private void readWriteTwoBytes(int port, int... bytes) throws Exception {
+        ByteBuf buffer = Unpooled.buffer();
+        TransportPort.of(port).write2Bytes(buffer);
+        assertThat(buffer.readableBytes(),equalTo(2));
+        for(int i=0; i<bytes.length;i++) {
+            assertThat(buffer.readByte(), equalTo((byte) bytes[i]));
+        }
+        assertThat(buffer.isReadable(), is(false));
+
+        buffer.clear();
+        for(int b: bytes) {
+            buffer.writeByte(b);
+        }
+        assertThat(TransportPort.read2Bytes(buffer), equalTo(TransportPort.of(port)));
+     }
+
+     @Test
+     public void testCompare() {
+         assertThat(TransportPort.of(1), lessThan(TransportPort.of(2)));
+         assertThat(TransportPort.of(0x7FFF), lessThan(TransportPort.of(0x8000)));
+         assertThat(TransportPort.of(1), lessThan(TransportPort.of(0xFFFF)));
+     }
+
+ }


### PR DESCRIPTION
Reviewer: trivial
CC: @Sovietaced @sdmodi 

Cherry-pick of #637 to the (newly) created bcf-4.7.x branch.

TransportPort is a short (2-byte) field; is is read and written as 2
bytes. However, for normalization purposes, we were looking for a 4-byte
0xFFFF_FFFF value to signify a fully set MASK (i.e., no bits marked
out).

This would mean that if the controller would send an OXe containing
tcp_dst_port_masked:1234/0xFFFF, the switch would store and report
back tcp_dst:1234 (unmasked), which would lead to VFT consistency
errors.