### PR TITLE
Add active, link_state, and fail_count TLVs

### DIFF
--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1417,3 +1417,26 @@ struct of_bsn_tlv_src_mac_cml : of_bsn_tlv {
     uint16_t length;
     enum ofp_bsn_cml value;
 };
+
+struct of_bsn_tlv_active : of_bsn_tlv {
+    uint16_t type == 192;
+    uint16_t length;
+    of_octets_t value;
+};
+
+enum ofp_bsn_link_state(wire_type=uint8_t) {
+    OFP_BSN_LINK_STATE_DOWN = 0,
+    OFP_BSN_LINK_STATE_UP = 1,
+};
+
+struct of_bsn_tlv_link_state : of_bsn_tlv {
+    uint16_t type == 193;
+    uint16_t length;
+    enum ofp_bsn_link_state value;
+};
+
+struct of_bsn_tlv_fail_count : of_bsn_tlv {
+    uint16_t type == 194;
+    uint16_t length;
+    uint64_t value;
+};

--- a/openflow_input/bsn_tlv
+++ b/openflow_input/bsn_tlv
@@ -1421,18 +1421,11 @@ struct of_bsn_tlv_src_mac_cml : of_bsn_tlv {
 struct of_bsn_tlv_active : of_bsn_tlv {
     uint16_t type == 192;
     uint16_t length;
-    of_octets_t value;
 };
 
-enum ofp_bsn_link_state(wire_type=uint8_t) {
-    OFP_BSN_LINK_STATE_DOWN = 0,
-    OFP_BSN_LINK_STATE_UP = 1,
-};
-
-struct of_bsn_tlv_link_state : of_bsn_tlv {
+struct of_bsn_tlv_link_up : of_bsn_tlv {
     uint16_t type == 193;
     uint16_t length;
-    enum ofp_bsn_link_state value;
 };
 
 struct of_bsn_tlv_fail_count : of_bsn_tlv {


### PR DESCRIPTION
Reviewer: @poolakiran @shudongz 
This allows additional info to be reported to controller for redundant management interfaces.