### PR TITLE
LOXI-83: normalize uint{8,16,32}_t values in ctors

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U128.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U128.java
@@ -2,12 +2,12 @@ package org.projectfloodlight.openflow.types;
 
 import javax.annotation.Nonnull;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedLongs;
 
-public class U128 implements OFValueType<U128>, HashValue<U128> {
+import io.netty.buffer.ByteBuf;
+
+public final class U128 implements OFValueType<U128>, HashValue<U128> {
 
     static final int LENGTH = 16;
     private static final long UNSIGNED_MASK = 0x7fffffffffffffffL;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
@@ -17,13 +17,14 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Ints;
+
+import io.netty.buffer.ByteBuf;
 
 public class U16 implements Writeable, OFValueType<U16> {
     private final static short ZERO_VAL = 0;
@@ -39,6 +40,10 @@ public class U16 implements Writeable, OFValueType<U16> {
 
     public static short t(final int l) {
         return (short) l;
+    }
+
+    public static int normalize(int value) {
+        return (short) (value & 0xFFFF);
     }
 
     private final short raw;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
@@ -26,7 +26,7 @@ import com.google.common.primitives.Ints;
 
 import io.netty.buffer.ByteBuf;
 
-public class U16 implements Writeable, OFValueType<U16> {
+public final class U16 implements Writeable, OFValueType<U16> {
     private final static short ZERO_VAL = 0;
     public final static U16 ZERO = new U16(ZERO_VAL);
 
@@ -52,11 +52,11 @@ public class U16 implements Writeable, OFValueType<U16> {
         this.raw = raw;
     }
 
-    public static final U16 of(int value) {
+    public static U16 of(int value) {
         return ofRaw(t(value));
     }
 
-    public static final U16 ofRaw(short raw) {
+    public static U16 ofRaw(short raw) {
         if(raw == ZERO_VAL)
             return ZERO;
         return new U16(raw);

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U32.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U32.java
@@ -17,13 +17,14 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 public class U32 implements Writeable, OFValueType<U32> {
     private final static int ZERO_VAL = 0;
@@ -93,6 +94,10 @@ public class U32 implements Writeable, OFValueType<U32> {
 
     public static int t(final long l) {
         return (int) l;
+    }
+
+    public static long normalize(long value) {
+        return value & 0xFFFF_FFFFL;
     }
 
     @Override

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U32.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U32.java
@@ -26,7 +26,7 @@ import com.google.common.primitives.UnsignedInts;
 
 import io.netty.buffer.ByteBuf;
 
-public class U32 implements Writeable, OFValueType<U32> {
+public final class U32 implements Writeable, OFValueType<U32> {
     private final static int ZERO_VAL = 0;
     public final static U32 ZERO = new U32(ZERO_VAL);
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U64.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U64.java
@@ -19,7 +19,6 @@ package org.projectfloodlight.openflow.types;
 
 import java.math.BigInteger;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
 import org.projectfloodlight.openflow.protocol.Writeable;
@@ -27,7 +26,9 @@ import org.projectfloodlight.openflow.protocol.Writeable;
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedLongs;
 
-public class U64 implements Writeable, OFValueType<U64>, HashValue<U64> {
+import io.netty.buffer.ByteBuf;
+
+public  final class U64 implements Writeable, OFValueType<U64>, HashValue<U64> {
     private static final long UNSIGNED_MASK = 0x7fffffffffffffffL;
     private final static long ZERO_VAL = 0;
     public final static U64 ZERO = new U64(ZERO_VAL);

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U8.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U8.java
@@ -17,13 +17,14 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedBytes;
+
+import io.netty.buffer.ByteBuf;
 
 public class U8 implements Writeable, OFValueType<U8> {
     private final static byte ZERO_VAL = 0;
@@ -50,6 +51,10 @@ public class U8 implements Writeable, OFValueType<U8> {
 
     public static final U8 ofRaw(byte value) {
         return new U8(value);
+    }
+
+    public static short normalize(short value) {
+        return (short) (value & 0xFF);
     }
 
     public short getValue() {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U8.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U8.java
@@ -26,7 +26,7 @@ import com.google.common.primitives.UnsignedBytes;
 
 import io.netty.buffer.ByteBuf;
 
-public class U8 implements Writeable, OFValueType<U8> {
+public final class U8 implements Writeable, OFValueType<U8> {
     private final static byte ZERO_VAL = 0;
     public final static U8 ZERO = new U8(ZERO_VAL);
 
@@ -40,7 +40,7 @@ public class U8 implements Writeable, OFValueType<U8> {
         this.raw = raw;
     }
 
-    public static final U8 of(short value) {
+    public static U8 of(short value) {
         if(value == ZERO_VAL)
             return ZERO;
         if(value == NO_MASK_VAL)
@@ -49,7 +49,7 @@ public class U8 implements Writeable, OFValueType<U8> {
         return new U8(t(value));
     }
 
-    public static final U8 ofRaw(byte value) {
+    public static U8 ofRaw(byte value) {
         return new U8(value);
     }
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/PrimitiveNormalizationTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/PrimitiveNormalizationTest.java
@@ -1,0 +1,50 @@
+package org.projectfloodlight.protocol.match;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.projectfloodlight.openflow.protocol.OFFactories;
+import org.projectfloodlight.openflow.protocol.OFFactory;
+import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.types.OFPort;
+
+/** Tests that primitives U8, U16, U32 are normalized in the constructor of our OFObjects. This is chosen
+ * on three randomly picked examples of OFObjects that contain values of these types. */
+public class PrimitiveNormalizationTest {
+    private final OFFactory factory = OFFactories.getFactory(OFVersion.OF_14);
+
+    @Test
+    public void normalizeU8() {
+        assertThat(factory.bsnTlvs().vlanPcp((short) -1), equalTo(factory.bsnTlvs().vlanPcp((short) 0xFF)));
+        assertThat(factory.bsnTlvs().vlanPcp((short) -1), not(factory.bsnTlvs().vlanPcp((short) 0)));
+        assertThat(factory.bsnTlvs().vlanPcp((short) -1), not(factory.bsnTlvs().vlanPcp((short) 1)));
+        assertThat(factory.bsnTlvs().vlanPcp((short) 1), not(factory.bsnTlvs().vlanPcp((short) 2)));
+        assertThat(factory.bsnTlvs().vlanPcp((short) -1), not(factory.bsnTlvs().vlanPcp((short) -2)));
+        assertThat(factory.bsnTlvs().buildVlanPcp().setValue((short) -1).build(),
+                equalTo(factory.bsnTlvs().vlanPcp((short) 0xFF)));
+    }
+
+    @Test
+    public void normalizeU16() {
+        assertThat(factory.actions().output(OFPort.of(1), -1), equalTo(factory.actions().output(OFPort.of(1), 0xFFFF)));
+        assertThat(factory.actions().output(OFPort.of(1), -1), not(factory.actions().output(OFPort.of(1), 0)));
+        assertThat(factory.actions().output(OFPort.of(1), -1), not(factory.actions().output(OFPort.of(1), 1)));
+
+        assertThat(factory.actions().buildOutput().setPort(OFPort.of(1)).setMaxLen(-1).build(),
+                equalTo(factory.actions().output(OFPort.of(1), 0xFFFF)));
+    }
+
+
+    @Test
+    public void normalizeU32() {
+        assertThat(factory.bsnTlvs().mplsLabel(-1), equalTo(factory.bsnTlvs().mplsLabel(0xFFFF_FFFFFL)));
+        assertThat(factory.bsnTlvs().mplsLabel(-1), not(factory.bsnTlvs().mplsLabel(1)));
+        assertThat(factory.bsnTlvs().mplsLabel(-1), not(factory.bsnTlvs().mplsLabel(0)));
+
+        assertThat(factory.bsnTlvs().buildMplsLabel().setValue(-1).build(),
+                equalTo(factory.bsnTlvs().mplsLabel(0xFFFF_FFFFFL)));
+    }
+
+}

--- a/java_gen/templates/of_class.java
+++ b/java_gen/templates/of_class.java
@@ -81,7 +81,7 @@ class ${impl_class} implements ${msg.interface.inherited_declaration()} {
 //::   #endif
 //:: #endfor
 //:: for prop in msg.data_members:
-        this.${prop.name} = ${prop.name};
+        this.${prop.name} = ${prop.java_type.normalize_op(version, prop.name, pub_type=True)};
 //:: #endfor
     }
     //:: else:


### PR DESCRIPTION
CC: @chichong-bsn @sdmodi 

We represent uint8,16,32 values by the next larger primitive numeric type in
Java, i.e., `uint8_t` is represented by `short`, not `byte`. This is done
because the Java types are internally signed and we want unsigned values
for output and input. (*)

However, this creates a problem if somebody inputs a value that is
partially represented by the underlying value, e.g., if they put in a
short "-1" to mean 0xFF. This is a fairly common practice, esp. in C.

Until now this could mean you could have two different OF objects containing a `uint8` — one
that has short '255' = `0xFF` and one that has short '-1' =`0xFFFF` in it. But because
the value uint_8 serializes to 8 bits on the wire, they would come out
to the same on the wire (and for the switch). Two OF objects should be
the same if they are the same on the wire.

Thus, we now normalize those unsigned values to their effective value
range in the constructor of the objects. This ensures that two logically
identical objects (which will be the same on the wire) are also the same
for Java.

(*) That may have been a stupid idea of mine, but it is what it is 🙃 