### PR TITLE
LOXI-83: fix bug normalization of U16

### DIFF
--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/U16.java
@@ -43,7 +43,7 @@ public final class U16 implements Writeable, OFValueType<U16> {
     }
 
     public static int normalize(int value) {
-        return (short) (value & 0xFFFF);
+        return value & 0xFFFF;
     }
 
     private final short raw;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U16Test.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U16Test.java
@@ -1,0 +1,20 @@
+package org.projectfloodlight.openflow.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class U16Test {
+
+    @Test
+    public void normalize() {
+        assertEquals(0,     U16.normalize((short) 0));
+        assertEquals(1,     U16.normalize((short) 1));
+        assertEquals(32767, U16.normalize((short) 32767));
+        assertEquals(32768, U16.normalize((short) 32768));
+        assertEquals(65535, U16.normalize((short) 65535));
+        assertEquals(0,     U16.normalize((short) 65536));
+        assertEquals(65535, U16.normalize((short) -1));
+    }
+
+}

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U32Test.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U32Test.java
@@ -1,0 +1,19 @@
+package org.projectfloodlight.openflow.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class U32Test {
+
+    @Test
+    public void normalize() {
+        assertEquals(0,           U32.normalize((short) 0));
+        assertEquals(1,           U32.normalize((short) 1));
+        assertEquals(2147483647L, U32.normalize(2147483647L));
+        assertEquals(2147483648L, U32.normalize(2147483648L));
+        assertEquals(4294967295L, U32.normalize((short) 4294967295L));
+        assertEquals(0L,          U32.normalize((short) 4294967296L));
+        assertEquals(0xFFFF_FFFFL, U32.normalize(-1));
+    }
+}

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U8Test.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U8Test.java
@@ -1,0 +1,19 @@
+package org.projectfloodlight.openflow.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class U8Test {
+
+    @Test
+    public void normalize() {
+        assertEquals((short)0, U8.normalize((short) 0));
+        assertEquals((short)1, U8.normalize((short) 1));
+        assertEquals((short)127, U8.normalize((short) 127));
+        assertEquals((short)128, U8.normalize((short) 128));
+        assertEquals((short)254, U8.normalize((short) 254));
+        assertEquals((short)255, U8.normalize((short) 255));
+        assertEquals((short)255, U8.normalize((short) -1));
+    }
+}


### PR DESCRIPTION
Normalization, take to. Fixup for #649 

erroneous cast to short would make values greater than 32767 appears as signed/negative in U16. Exactly not what we want.

Also adds a unit test.