### PR TITLE
LOXI-89 LOXI-90: OpenflowJ dependency update; bump version to 3.6.x; require Java 8

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -117,8 +117,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.50.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -14,7 +14,7 @@
          Note that this only works for a standalone POM as done here; otherwise you need plugins
          resolve-parent-version-maven-plugin or flatten-maven-plugin (and both bring complexities).
     -->
-    <version>3.5.${revision}</version>
+    <version>3.6.${revision}</version>
     <packaging>jar</packaging>
 
     <name>OpenFlowJ-Loxi</name>

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.26</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageWriter.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFMessageWriter.java
@@ -1,7 +1,8 @@
 package org.projectfloodlight.openflow.protocol;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
+
+import io.netty.buffer.ByteBuf;
 
 public interface OFMessageWriter<T> {
     public void write(ByteBuf bb, T message) throws OFParseError;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFOxmList.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/OFOxmList.java
@@ -4,7 +4,6 @@ import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.protocol.match.MatchFields;
@@ -18,6 +17,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkable {
     private static final Logger logger = LoggerFactory.getLogger(OFOxmList.class);
@@ -39,7 +40,7 @@ public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkab
         private final Map<MatchFields, OFOxm<?>> oxmMap;
 
         public Builder() {
-            oxmMap = new EnumMap<MatchFields, OFOxm<?>>(MatchFields.class);
+            oxmMap = new EnumMap<>(MatchFields.class);
         }
 
         public Builder(EnumMap<MatchFields, OFOxm<?>> oxmMap) {
@@ -65,7 +66,7 @@ public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkab
     }
 
     public static OFOxmList ofList(Iterable<OFOxm<?>> oxmList) {
-        Map<MatchFields, OFOxm<?>> map = new EnumMap<MatchFields, OFOxm<?>>(
+        Map<MatchFields, OFOxm<?>> map = new EnumMap<>(
                 MatchFields.class);
         for (OFOxm<?> o : oxmList) {
             OFOxm<?> canonical = o.getCanonical();
@@ -82,7 +83,7 @@ public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkab
     }
 
     public static OFOxmList of(OFOxm<?>... oxms) {
-        Map<MatchFields, OFOxm<?>> map = new EnumMap<MatchFields, OFOxm<?>>(
+        Map<MatchFields, OFOxm<?>> map = new EnumMap<>(
                 MatchFields.class);
         for (OFOxm<?> o : oxms) {
             OFOxm<?> canonical = o.getCanonical();
@@ -110,7 +111,7 @@ public class OFOxmList implements Iterable<OFOxm<?>>, Writeable, PrimitiveSinkab
     }
 
     public OFOxmList.Builder createBuilder() {
-        return new OFOxmList.Builder(new EnumMap<MatchFields, OFOxm<?>>(oxmMap));
+        return new OFOxmList.Builder(new EnumMap<>(oxmMap));
     }
 
     @Override

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/MatchField.java
@@ -1,5 +1,7 @@
 package org.projectfloodlight.openflow.protocol.match;
 
+import java.util.Set;
+
 import org.projectfloodlight.openflow.types.ArpOpcode;
 import org.projectfloodlight.openflow.types.ClassId;
 import org.projectfloodlight.openflow.types.EthType;
@@ -20,20 +22,19 @@ import org.projectfloodlight.openflow.types.OFMetadata;
 import org.projectfloodlight.openflow.types.OFPort;
 import org.projectfloodlight.openflow.types.OFValueType;
 import org.projectfloodlight.openflow.types.OFVlanVidMatch;
-import org.projectfloodlight.openflow.types.TransportPort;
 import org.projectfloodlight.openflow.types.PacketType;
+import org.projectfloodlight.openflow.types.TransportPort;
+import org.projectfloodlight.openflow.types.U128;
 import org.projectfloodlight.openflow.types.U16;
 import org.projectfloodlight.openflow.types.U32;
 import org.projectfloodlight.openflow.types.U64;
-import org.projectfloodlight.openflow.types.U128;
 import org.projectfloodlight.openflow.types.U8;
 import org.projectfloodlight.openflow.types.UDF;
+import org.projectfloodlight.openflow.types.VFI;
 import org.projectfloodlight.openflow.types.VRF;
 import org.projectfloodlight.openflow.types.VlanPcp;
 import org.projectfloodlight.openflow.types.VxlanNI;
-import org.projectfloodlight.openflow.types.VFI;
 
-import java.util.Set;
 import com.google.common.collect.ImmutableSet;
 
 public class MatchField<F extends OFValueType<F>> {
@@ -49,301 +50,301 @@ public class MatchField<F extends OFValueType<F>> {
     }
 
     public final static MatchField<OFPort> IN_PORT =
-            new MatchField<OFPort>("in_port", MatchFields.IN_PORT);
+            new MatchField<>("in_port", MatchFields.IN_PORT);
 
     public final static MatchField<OFPort> IN_PHY_PORT =
-            new MatchField<OFPort>("in_phy_port", MatchFields.IN_PHY_PORT,
-                    new Prerequisite<OFPort>(MatchField.IN_PORT));
+            new MatchField<>("in_phy_port", MatchFields.IN_PHY_PORT,
+                    new Prerequisite<>(MatchField.IN_PORT));
 
     public final static MatchField<OFMetadata> METADATA =
-            new MatchField<OFMetadata>("metadata", MatchFields.METADATA);
+            new MatchField<>("metadata", MatchFields.METADATA);
 
     public final static MatchField<MacAddress> ETH_DST =
-            new MatchField<MacAddress>("eth_dst", MatchFields.ETH_DST);
+            new MatchField<>("eth_dst", MatchFields.ETH_DST);
 
     public final static MatchField<MacAddress> ETH_SRC =
-            new MatchField<MacAddress>("eth_src", MatchFields.ETH_SRC);
+            new MatchField<>("eth_src", MatchFields.ETH_SRC);
 
     public final static MatchField<EthType> ETH_TYPE =
-            new MatchField<EthType>("eth_type", MatchFields.ETH_TYPE);
+            new MatchField<>("eth_type", MatchFields.ETH_TYPE);
 
     public final static MatchField<OFVlanVidMatch> VLAN_VID =
-            new MatchField<OFVlanVidMatch>("vlan_vid", MatchFields.VLAN_VID);
+            new MatchField<>("vlan_vid", MatchFields.VLAN_VID);
 
     public final static MatchField<VlanPcp> VLAN_PCP =
-            new MatchField<VlanPcp>("vlan_pcp", MatchFields.VLAN_PCP,
-                    new Prerequisite<OFVlanVidMatch>(MatchField.VLAN_VID));
+            new MatchField<>("vlan_pcp", MatchFields.VLAN_PCP,
+                    new Prerequisite<>(MatchField.VLAN_VID));
 
     public final static MatchField<IpDscp> IP_DSCP =
-            new MatchField<IpDscp>("ip_dscp", MatchFields.IP_DSCP,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
+            new MatchField<>("ip_dscp", MatchFields.IP_DSCP,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
 
     public final static MatchField<IpEcn> IP_ECN =
-            new MatchField<IpEcn>("ip_ecn", MatchFields.IP_ECN,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
+            new MatchField<>("ip_ecn", MatchFields.IP_ECN,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
 
     public final static MatchField<IpProtocol> IP_PROTO =
-            new MatchField<IpProtocol>("ip_proto", MatchFields.IP_PROTO,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
+            new MatchField<>("ip_proto", MatchFields.IP_PROTO,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
 
     public final static MatchField<IPv4Address> IPV4_SRC =
-            new MatchField<IPv4Address>("ipv4_src", MatchFields.IPV4_SRC,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4));
+            new MatchField<>("ipv4_src", MatchFields.IPV4_SRC,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4));
 
     public final static MatchField<IPv4Address> IPV4_DST =
-            new MatchField<IPv4Address>("ipv4_dst", MatchFields.IPV4_DST,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4));
+            new MatchField<>("ipv4_dst", MatchFields.IPV4_DST,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4));
 
-    public final static MatchField<TransportPort> TCP_SRC = new MatchField<TransportPort>(
+    public final static MatchField<TransportPort> TCP_SRC = new MatchField<>(
             "tcp_src", MatchFields.TCP_SRC,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.TCP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.TCP));
 
-    public final static MatchField<TransportPort> TCP_DST = new MatchField<TransportPort>(
+    public final static MatchField<TransportPort> TCP_DST = new MatchField<>(
             "tcp_dst", MatchFields.TCP_DST,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.TCP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.TCP));
 
-    public final static MatchField<TransportPort> UDP_SRC = new MatchField<TransportPort>(
+    public final static MatchField<TransportPort> UDP_SRC = new MatchField<>(
             "udp_src", MatchFields.UDP_SRC,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.UDP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.UDP));
 
-    public final static MatchField<TransportPort> UDP_DST = new MatchField<TransportPort>(
+    public final static MatchField<TransportPort> UDP_DST = new MatchField<>(
             "udp_dst", MatchFields.UDP_DST,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.UDP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.UDP));
 
-    public final static MatchField<TransportPort> SCTP_SRC = new MatchField<TransportPort>(
+    public final static MatchField<TransportPort> SCTP_SRC = new MatchField<>(
             "sctp_src", MatchFields.SCTP_SRC,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.SCTP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.SCTP));
 
-    public final static MatchField<TransportPort> SCTP_DST = new MatchField<TransportPort>(
+    public final static MatchField<TransportPort> SCTP_DST = new MatchField<>(
             "sctp_dst", MatchFields.SCTP_DST,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.SCTP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.SCTP));
 
-    public final static MatchField<ICMPv4Type> ICMPV4_TYPE = new MatchField<ICMPv4Type>(
+    public final static MatchField<ICMPv4Type> ICMPV4_TYPE = new MatchField<>(
             "icmpv4_type", MatchFields.ICMPV4_TYPE,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.ICMP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.ICMP));
 
-    public final static MatchField<ICMPv4Code> ICMPV4_CODE = new MatchField<ICMPv4Code>(
+    public final static MatchField<ICMPv4Code> ICMPV4_CODE = new MatchField<>(
             "icmpv4_code", MatchFields.ICMPV4_CODE,
-            new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.ICMP));
+            new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.ICMP));
 
-    public final static MatchField<ArpOpcode> ARP_OP = new MatchField<ArpOpcode>(
+    public final static MatchField<ArpOpcode> ARP_OP = new MatchField<>(
             "arp_op", MatchFields.ARP_OP,
-            new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ARP));
+            new Prerequisite<>(MatchField.ETH_TYPE, EthType.ARP));
 
     public final static MatchField<IPv4Address> ARP_SPA =
-            new MatchField<IPv4Address>("arp_spa", MatchFields.ARP_SPA,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ARP));
+            new MatchField<>("arp_spa", MatchFields.ARP_SPA,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.ARP));
 
     public final static MatchField<IPv4Address> ARP_TPA =
-            new MatchField<IPv4Address>("arp_tpa", MatchFields.ARP_TPA,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ARP));
+            new MatchField<>("arp_tpa", MatchFields.ARP_TPA,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.ARP));
 
     public final static MatchField<MacAddress> ARP_SHA =
-            new MatchField<MacAddress>("arp_sha", MatchFields.ARP_SHA,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ARP));
+            new MatchField<>("arp_sha", MatchFields.ARP_SHA,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.ARP));
 
     public final static MatchField<MacAddress> ARP_THA =
-            new MatchField<MacAddress>("arp_tha", MatchFields.ARP_THA,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.ARP));
+            new MatchField<>("arp_tha", MatchFields.ARP_THA,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.ARP));
 
     public final static MatchField<IPv6Address> IPV6_SRC =
-            new MatchField<IPv6Address>("ipv6_src", MatchFields.IPV6_SRC,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+            new MatchField<>("ipv6_src", MatchFields.IPV6_SRC,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv6));
 
     public final static MatchField<IPv6Address> IPV6_DST =
-            new MatchField<IPv6Address>("ipv6_dst", MatchFields.IPV6_DST,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+            new MatchField<>("ipv6_dst", MatchFields.IPV6_DST,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv6));
 
     public final static MatchField<IPv6FlowLabel> IPV6_FLABEL =
-            new MatchField<IPv6FlowLabel>("ipv6_flabel", MatchFields.IPV6_FLABEL,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+            new MatchField<>("ipv6_flabel", MatchFields.IPV6_FLABEL,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv6));
 
     public final static MatchField<U8> ICMPV6_TYPE =
-            new MatchField<U8>("icmpv6_type", MatchFields.ICMPV6_TYPE,
-                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.IPv6_ICMP));
+            new MatchField<>("icmpv6_type", MatchFields.ICMPV6_TYPE,
+                    new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.IPv6_ICMP));
 
     public final static MatchField<U8> ICMPV6_CODE =
-            new MatchField<U8>("icmpv6_code", MatchFields.ICMPV6_CODE,
-                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.IPv6_ICMP));
+            new MatchField<>("icmpv6_code", MatchFields.ICMPV6_CODE,
+                    new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.IPv6_ICMP));
 
     public final static MatchField<IPv6Address> IPV6_ND_TARGET =
-            new MatchField<IPv6Address>("ipv6_nd_target", MatchFields.IPV6_ND_TARGET,
-                    new Prerequisite<U8>(MatchField.ICMPV6_TYPE, U8.of((short)135), U8.of((short)136)));
+            new MatchField<>("ipv6_nd_target", MatchFields.IPV6_ND_TARGET,
+                    new Prerequisite<>(MatchField.ICMPV6_TYPE, U8.of((short) 135), U8.of((short) 136)));
 
     public final static MatchField<MacAddress> IPV6_ND_SLL =
-            new MatchField<MacAddress>("ipv6_nd_sll", MatchFields.IPV6_ND_SLL,
-                    new Prerequisite<U8>(MatchField.ICMPV6_TYPE, U8.of((short)135)));
+            new MatchField<>("ipv6_nd_sll", MatchFields.IPV6_ND_SLL,
+                    new Prerequisite<>(MatchField.ICMPV6_TYPE, U8.of((short) 135)));
 
     public final static MatchField<MacAddress> IPV6_ND_TLL =
-            new MatchField<MacAddress>("ipv6_nd_tll", MatchFields.IPV6_ND_TLL,
-                    new Prerequisite<U8>(MatchField.ICMPV6_TYPE, U8.of((short)136)));
+            new MatchField<>("ipv6_nd_tll", MatchFields.IPV6_ND_TLL,
+                    new Prerequisite<>(MatchField.ICMPV6_TYPE, U8.of((short) 136)));
 
     public final static MatchField<U32> MPLS_LABEL =
-            new MatchField<U32>("mpls_label", MatchFields.MPLS_LABEL,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.MPLS_UNICAST, EthType.MPLS_MULTICAST));
+            new MatchField<>("mpls_label", MatchFields.MPLS_LABEL,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.MPLS_UNICAST, EthType.MPLS_MULTICAST));
 
     public final static MatchField<U8> MPLS_TC =
-            new MatchField<U8>("mpls_tc", MatchFields.MPLS_TC,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.MPLS_UNICAST, EthType.MPLS_MULTICAST));
+            new MatchField<>("mpls_tc", MatchFields.MPLS_TC,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.MPLS_UNICAST, EthType.MPLS_MULTICAST));
 
     public final static MatchField<OFBooleanValue> MPLS_BOS =
-            new MatchField<OFBooleanValue>("mpls_bos", MatchFields.MPLS_BOS,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.MPLS_UNICAST, EthType.MPLS_MULTICAST));
+            new MatchField<>("mpls_bos", MatchFields.MPLS_BOS,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.MPLS_UNICAST, EthType.MPLS_MULTICAST));
 
     public final static MatchField<U64> TUNNEL_ID =
-            new MatchField<U64>("tunnel_id", MatchFields.TUNNEL_ID);
+            new MatchField<>("tunnel_id", MatchFields.TUNNEL_ID);
 
     public final static MatchField<U16> IPV6_EXTHDR =
-            new MatchField<U16>("ipv6_exthdr", MatchFields.IPV6_EXTHDR,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+            new MatchField<>("ipv6_exthdr", MatchFields.IPV6_EXTHDR,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv6));
 
     public final static MatchField<OFBooleanValue> PBB_UCA =
-            new MatchField<OFBooleanValue>("pbb_uca", MatchFields.PBB_UCA,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.PBB));
+            new MatchField<>("pbb_uca", MatchFields.PBB_UCA,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.PBB));
 
     public final static MatchField<U16> TCP_FLAGS =
-            new MatchField<U16>("tcp_flags", MatchFields.TCP_FLAGS,
-                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.TCP));
+            new MatchField<>("tcp_flags", MatchFields.TCP_FLAGS,
+                    new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.TCP));
 
     public final static MatchField<U16> OVS_TCP_FLAGS =
-            new MatchField<U16>("ovs_tcp_flags", MatchFields.OVS_TCP_FLAGS,
-                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.TCP));
+            new MatchField<>("ovs_tcp_flags", MatchFields.OVS_TCP_FLAGS,
+                    new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.TCP));
 
     public final static MatchField<PacketType> PACKET_TYPE =
-            new MatchField<PacketType>("packet_type", MatchFields.PACKET_TYPE);
+            new MatchField<>("packet_type", MatchFields.PACKET_TYPE);
 
     public final static MatchField<OFPort> ACTSET_OUTPUT =
-            new MatchField<OFPort>("actset_output", MatchFields.ACTSET_OUTPUT);
+            new MatchField<>("actset_output", MatchFields.ACTSET_OUTPUT);
 
     public final static MatchField<IPv4Address> TUNNEL_IPV4_SRC =
-            new MatchField<IPv4Address>("tunnel_ipv4_src", MatchFields.TUNNEL_IPV4_SRC,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4));
+            new MatchField<>("tunnel_ipv4_src", MatchFields.TUNNEL_IPV4_SRC,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4));
 
     public final static MatchField<IPv4Address> TUNNEL_IPV4_DST =
-            new MatchField<IPv4Address>("tunnel_ipv4_dst", MatchFields.TUNNEL_IPV4_DST,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4));
+            new MatchField<>("tunnel_ipv4_dst", MatchFields.TUNNEL_IPV4_DST,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4));
 
     public final static MatchField<OFBitMask128> BSN_IN_PORTS_128 =
-            new MatchField<OFBitMask128>("bsn_in_ports_128", MatchFields.BSN_IN_PORTS_128);
+            new MatchField<>("bsn_in_ports_128", MatchFields.BSN_IN_PORTS_128);
 
     public final static MatchField<OFBitMask512> BSN_IN_PORTS_512 =
-            new MatchField<OFBitMask512>("bsn_in_ports_512", MatchFields.BSN_IN_PORTS_512);
+            new MatchField<>("bsn_in_ports_512", MatchFields.BSN_IN_PORTS_512);
 
     public final static MatchField<LagId> BSN_LAG_ID =
-            new MatchField<LagId>("bsn_lag_id", MatchFields.BSN_LAG_ID);
+            new MatchField<>("bsn_lag_id", MatchFields.BSN_LAG_ID);
 
     public final static MatchField<VRF> BSN_VRF =
-            new MatchField<VRF>("bsn_vrf", MatchFields.BSN_VRF);
+            new MatchField<>("bsn_vrf", MatchFields.BSN_VRF);
 
     public final static MatchField<OFBooleanValue> BSN_GLOBAL_VRF_ALLOWED =
-            new MatchField<OFBooleanValue>("bsn_global_vrf_allowed", MatchFields.BSN_GLOBAL_VRF_ALLOWED);
+            new MatchField<>("bsn_global_vrf_allowed", MatchFields.BSN_GLOBAL_VRF_ALLOWED);
 
     public final static MatchField<ClassId> BSN_L3_INTERFACE_CLASS_ID =
-            new MatchField<ClassId>("bsn_l3_interface_class_id", MatchFields.BSN_L3_INTERFACE_CLASS_ID);
+            new MatchField<>("bsn_l3_interface_class_id", MatchFields.BSN_L3_INTERFACE_CLASS_ID);
 
     public final static MatchField<ClassId> BSN_L3_SRC_CLASS_ID =
-            new MatchField<ClassId>("bsn_l3_src_class_id", MatchFields.BSN_L3_SRC_CLASS_ID);
+            new MatchField<>("bsn_l3_src_class_id", MatchFields.BSN_L3_SRC_CLASS_ID);
 
     public final static MatchField<ClassId> BSN_L3_DST_CLASS_ID =
-            new MatchField<ClassId>("bsn_l3_dst_class_id", MatchFields.BSN_L3_DST_CLASS_ID);
+            new MatchField<>("bsn_l3_dst_class_id", MatchFields.BSN_L3_DST_CLASS_ID);
 
     public final static MatchField<ClassId> BSN_EGR_PORT_GROUP_ID =
-            new MatchField<ClassId>("bsn_egr_port_group_id", MatchFields.BSN_EGR_PORT_GROUP_ID);
+            new MatchField<>("bsn_egr_port_group_id", MatchFields.BSN_EGR_PORT_GROUP_ID);
 
     public final static MatchField<ClassId> BSN_INGRESS_PORT_GROUP_ID =
-            new MatchField<ClassId>("bsn_ingress_port_group_id", MatchFields.BSN_INGRESS_PORT_GROUP_ID);
+            new MatchField<>("bsn_ingress_port_group_id", MatchFields.BSN_INGRESS_PORT_GROUP_ID);
 
     public final static MatchField<UDF> BSN_UDF0 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF0);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF0);
 
     public final static MatchField<UDF> BSN_UDF1 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF1);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF1);
 
     public final static MatchField<UDF> BSN_UDF2 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF2);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF2);
 
     public final static MatchField<UDF> BSN_UDF3 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF3);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF3);
 
     public final static MatchField<UDF> BSN_UDF4 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF4);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF4);
 
     public final static MatchField<UDF> BSN_UDF5 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF5);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF5);
 
     public final static MatchField<UDF> BSN_UDF6 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF6);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF6);
 
     public final static MatchField<UDF> BSN_UDF7 =
-            new MatchField<UDF>("bsn_udf", MatchFields.BSN_UDF7);
+            new MatchField<>("bsn_udf", MatchFields.BSN_UDF7);
 
     public final static MatchField<U16> BSN_TCP_FLAGS =
-            new MatchField<U16>("bsn_tcp_flags", MatchFields.BSN_TCP_FLAGS);
+            new MatchField<>("bsn_tcp_flags", MatchFields.BSN_TCP_FLAGS);
 
     public final static MatchField<ClassId> BSN_VLAN_XLATE_PORT_GROUP_ID =
-            new MatchField<ClassId>("bsn_vlan_xlate_port_group_id", MatchFields.BSN_VLAN_XLATE_PORT_GROUP_ID);
+            new MatchField<>("bsn_vlan_xlate_port_group_id", MatchFields.BSN_VLAN_XLATE_PORT_GROUP_ID);
 
     public final static MatchField<OFBooleanValue> BSN_L2_CACHE_HIT =
-            new MatchField<OFBooleanValue>("bsn_l2_cache_hit", MatchFields.BSN_L2_CACHE_HIT);
+            new MatchField<>("bsn_l2_cache_hit", MatchFields.BSN_L2_CACHE_HIT);
 
     public final static MatchField<VxlanNI> BSN_VXLAN_NETWORK_ID =
-            new MatchField<VxlanNI>("bsn_vxlan_network_id", MatchFields.BSN_VXLAN_NETWORK_ID);
+            new MatchField<>("bsn_vxlan_network_id", MatchFields.BSN_VXLAN_NETWORK_ID);
 
     public final static MatchField<MacAddress> BSN_INNER_ETH_DST =
-            new MatchField<MacAddress>("bsn_inner_eth_dst", MatchFields.BSN_INNER_ETH_DST);
+            new MatchField<>("bsn_inner_eth_dst", MatchFields.BSN_INNER_ETH_DST);
 
     public final static MatchField<MacAddress> BSN_INNER_ETH_SRC =
-            new MatchField<MacAddress>("bsn_inner_eth_src", MatchFields.BSN_INNER_ETH_SRC);
+            new MatchField<>("bsn_inner_eth_src", MatchFields.BSN_INNER_ETH_SRC);
 
     public final static MatchField<OFVlanVidMatch> BSN_INNER_VLAN_VID =
-            new MatchField<OFVlanVidMatch>("bsn_inner_vlan_vid", MatchFields.BSN_INNER_VLAN_VID);
+            new MatchField<>("bsn_inner_vlan_vid", MatchFields.BSN_INNER_VLAN_VID);
 
     public final static MatchField<VFI> BSN_VFI =
-            new MatchField<VFI>("bsn_vfi", MatchFields.BSN_VFI);
+            new MatchField<>("bsn_vfi", MatchFields.BSN_VFI);
 
     public final static MatchField<OFBooleanValue> BSN_IP_FRAGMENTATION =
-            new MatchField<OFBooleanValue>("bsn_ip_fragmentation", MatchFields.BSN_IP_FRAGMENTATION,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
+            new MatchField<>("bsn_ip_fragmentation", MatchFields.BSN_IP_FRAGMENTATION,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv4, EthType.IPv6));
 
     public final static MatchField<ClassId> BSN_IFP_CLASS_ID =
-            new MatchField<ClassId>("bsn_ifp_class_id", MatchFields.BSN_IFP_CLASS_ID);
+            new MatchField<>("bsn_ifp_class_id", MatchFields.BSN_IFP_CLASS_ID);
    
-    public final static MatchField<U32> CONN_TRACKING_STATE = 
-            new MatchField<U32>("conn_tracking_state", MatchFields.CONN_TRACKING_STATE);
+    public final static MatchField<U32> CONN_TRACKING_STATE =
+            new MatchField<>("conn_tracking_state", MatchFields.CONN_TRACKING_STATE);
 
-    public final static MatchField<U16> CONN_TRACKING_ZONE = 
-            new MatchField<U16>("conn_tracking_zone", MatchFields.CONN_TRACKING_ZONE);
+    public final static MatchField<U16> CONN_TRACKING_ZONE =
+            new MatchField<>("conn_tracking_zone", MatchFields.CONN_TRACKING_ZONE);
    
-    public final static MatchField<U32> CONN_TRACKING_MARK = 
-            new MatchField<U32>("conn_tracking_mark", MatchFields.CONN_TRACKING_MARK);
+    public final static MatchField<U32> CONN_TRACKING_MARK =
+            new MatchField<>("conn_tracking_mark", MatchFields.CONN_TRACKING_MARK);
 
-    public final static MatchField<U128> CONN_TRACKING_LABEL = 
-            new MatchField<U128>("conn_tracking_label", MatchFields.CONN_TRACKING_LABEL);
+    public final static MatchField<U128> CONN_TRACKING_LABEL =
+            new MatchField<>("conn_tracking_label", MatchFields.CONN_TRACKING_LABEL);
     
-    public final static MatchField<U8> CONN_TRACKING_NW_PROTO = 
-            new MatchField<U8>("conn_tracking_nw_proto", MatchFields.CONN_TRACKING_NW_PROTO);
+    public final static MatchField<U8> CONN_TRACKING_NW_PROTO =
+            new MatchField<>("conn_tracking_nw_proto", MatchFields.CONN_TRACKING_NW_PROTO);
 
-    public final static MatchField<U32> CONN_TRACKING_NW_SRC = 
-            new MatchField<U32>("conn_tracking_nw_src", MatchFields.CONN_TRACKING_NW_SRC);
+    public final static MatchField<U32> CONN_TRACKING_NW_SRC =
+            new MatchField<>("conn_tracking_nw_src", MatchFields.CONN_TRACKING_NW_SRC);
 
     public final static MatchField<U32> CONN_TRACKING_NW_DST =
-            new MatchField<U32>("conn_tracking_nw_dst", MatchFields.CONN_TRACKING_NW_DST);
+            new MatchField<>("conn_tracking_nw_dst", MatchFields.CONN_TRACKING_NW_DST);
     
     public final static MatchField<IPv6Address> CONN_TRACKING_IPV6_SRC =
-            new MatchField<IPv6Address>("conn_tracking_ipv6_src", MatchFields.CONN_TRACKING_IPV6_SRC,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+            new MatchField<>("conn_tracking_ipv6_src", MatchFields.CONN_TRACKING_IPV6_SRC,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv6));
     
     public final static MatchField<IPv6Address> CONN_TRACKING_IPV6_DST =
-            new MatchField<IPv6Address>("conn_tracking_ipv6_dst", MatchFields.CONN_TRACKING_IPV6_DST,
-                    new Prerequisite<EthType>(MatchField.ETH_TYPE, EthType.IPv6));
+            new MatchField<>("conn_tracking_ipv6_dst", MatchFields.CONN_TRACKING_IPV6_DST,
+                    new Prerequisite<>(MatchField.ETH_TYPE, EthType.IPv6));
     
-    public final static MatchField<TransportPort> CONN_TRACKING_TP_SRC = 
-            new MatchField<TransportPort>("conn_tracking_tp_src", MatchFields.CONN_TRACKING_TP_SRC,
-                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.TCP));
+    public final static MatchField<TransportPort> CONN_TRACKING_TP_SRC =
+            new MatchField<>("conn_tracking_tp_src", MatchFields.CONN_TRACKING_TP_SRC,
+                    new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.TCP));
     
     public final static MatchField<TransportPort> CONN_TRACKING_TP_DST =
-            new MatchField<TransportPort>("conn_tracking_tp_dst", MatchFields.CONN_TRACKING_TP_DST,
-                    new Prerequisite<IpProtocol>(MatchField.IP_PROTO, IpProtocol.TCP));
+            new MatchField<>("conn_tracking_tp_dst", MatchFields.CONN_TRACKING_TP_DST,
+                    new Prerequisite<>(MatchField.IP_PROTO, IpProtocol.TCP));
 
 
     public String getName() {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/match/Prerequisite.java
@@ -1,14 +1,15 @@
 package org.projectfloodlight.openflow.protocol.match;
 
 import java.util.Set;
-import com.google.common.collect.ImmutableSet;
 
 import org.projectfloodlight.openflow.types.OFValueType;
+
+import com.google.common.collect.ImmutableSet;
 
 public class Prerequisite<T extends OFValueType<T>> {
     private final MatchField<T> field;
     private final Set<OFValueType<T>> values;
-    private boolean any;
+    private final boolean any;
 
     @SafeVarargs
     public Prerequisite(MatchField<T> field, OFValueType<T>... values) {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver10/ChannelUtilsVer10.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver10/ChannelUtilsVer10.java
@@ -3,13 +3,14 @@ package org.projectfloodlight.openflow.protocol.ver10;
 import java.util.EnumSet;
 import java.util.Set;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFActionType;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver11/ChannelUtilsVer11.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver11/ChannelUtilsVer11.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.protocol.ver11;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver12/ChannelUtilsVer12.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver12/ChannelUtilsVer12.java
@@ -1,12 +1,12 @@
 package org.projectfloodlight.openflow.protocol.ver12;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
+import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
-import org.projectfloodlight.openflow.protocol.ver12.OFMatchV3Ver12;
-import org.projectfloodlight.openflow.protocol.OFBsnVportQInQ;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver13/ChannelUtilsVer13.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver13/ChannelUtilsVer13.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.protocol.ver13;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver14/ChannelUtilsVer14.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver14/ChannelUtilsVer14.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.protocol.ver14;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into ByteBufs

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver15/ChannelUtilsVer15.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/protocol/ver15/ChannelUtilsVer15.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.protocol.ver15;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMatchBmap;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.stat.Stat;
+
+import io.netty.buffer.ByteBuf;
 /**
  * Collection of helper functions for reading and writing into ByteBufs
  *

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ArpOpcode.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ArpOpcode.java
@@ -1,9 +1,9 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 public class ArpOpcode implements OFValueType<ArpOpcode> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/BundleId.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/BundleId.java
@@ -2,10 +2,10 @@ package org.projectfloodlight.openflow.types;
 
 import javax.annotation.concurrent.Immutable;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 @Immutable
 public class BundleId implements OFValueType<BundleId> {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ClassId.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ClassId.java
@@ -2,10 +2,10 @@ package org.projectfloodlight.openflow.types;
 
 import javax.annotation.concurrent.Immutable;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 @Immutable
 public class ClassId implements OFValueType<ClassId> {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/EthType.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/EthType.java
@@ -1,9 +1,9 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 
 /**

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/GenTableId.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/GenTableId.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 public class GenTableId implements OFValueType<GenTableId>, Comparable<GenTableId> {
     final static int LENGTH = 2;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ICMPv4Code.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ICMPv4Code.java
@@ -1,9 +1,9 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  *

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ICMPv4Type.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/ICMPv4Type.java
@@ -1,9 +1,9 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 public class ICMPv4Type implements OFValueType<ICMPv4Type> {
     final static int LENGTH = 1;

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv4Address.java
@@ -1,7 +1,5 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.Inet4Address;
@@ -18,6 +16,8 @@ import org.projectfloodlight.openflow.protocol.Writeable;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Wrapper around an IPv4Address address

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6Address.java
@@ -1,7 +1,5 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -20,6 +18,8 @@ import org.projectfloodlight.openflow.protocol.Writeable;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedLongs;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * IPv6 address object. Instance controlled, immutable. Internal representation:

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6FlowLabel.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IPv6FlowLabel.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 public class IPv6FlowLabel implements OFValueType<IPv6FlowLabel> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IpDscp.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IpDscp.java
@@ -1,9 +1,10 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public enum IpDscp implements OFValueType<IpDscp> {
     DSCP_0((byte)0),

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IpEcn.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IpEcn.java
@@ -1,9 +1,10 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public enum IpEcn implements OFValueType<IpEcn> {
     ECN_00((byte)0),

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IpProtocol.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/IpProtocol.java
@@ -1,9 +1,9 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * IP-Protocol field representation

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/LagId.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/LagId.java
@@ -2,10 +2,10 @@ package org.projectfloodlight.openflow.types;
 
 import javax.annotation.concurrent.Immutable;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 @Immutable
 public class LagId implements OFValueType<LagId> {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFAuxId.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFAuxId.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFAuxId implements Comparable<OFAuxId>, PrimitiveSinkable {
     

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBitMask128.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBitMask128.java
@@ -1,8 +1,8 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFBitMask128 implements OFValueType<OFBitMask128> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBitMask512.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBitMask512.java
@@ -1,8 +1,8 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFBitMask512 implements OFValueType<OFBitMask512> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBooleanValue.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFBooleanValue.java
@@ -17,12 +17,13 @@
 
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
 import org.projectfloodlight.openflow.protocol.Writeable;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFBooleanValue implements Writeable, OFValueType<OFBooleanValue> {
     public final static OFBooleanValue TRUE = new OFBooleanValue(true);

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFErrorCauseData.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFErrorCauseData.java
@@ -1,8 +1,5 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 import java.util.Arrays;
 
 import org.projectfloodlight.openflow.exceptions.OFParseError;
@@ -18,6 +15,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /** A special-purpose wrapper for the 'data' field in an {@link OFErrorMsg} message
  *  that contains a byte serialization of the offending message.

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFGroup.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFGroup.java
@@ -1,11 +1,12 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.annotations.Immutable;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Abstraction of an logical / OpenFlow group (ofp_group) in OpenFlow.

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFMetadata.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFMetadata.java
@@ -1,8 +1,8 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 public class OFMetadata implements OFValueType<OFMetadata> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPort.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFPort.java
@@ -1,11 +1,12 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.annotations.Immutable;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Abstraction of an logical / OpenFlow switch port (ofp_port_no) in OpenFlow.

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFVlanVidMatch.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/OFVlanVidMatch.java
@@ -4,13 +4,14 @@ import java.util.Arrays;
 
 import javax.annotation.Nullable;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 /** Represents an OpenFlow Vlan VID for use in Matches, as specified by the OpenFlow 1.3 spec.
  *

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/TableId.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/TableId.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 public class TableId implements OFValueType<TableId>, Comparable<TableId> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/UDF.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/UDF.java
@@ -2,10 +2,10 @@ package org.projectfloodlight.openflow.types;
 
 import javax.annotation.concurrent.Immutable;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 @Immutable
 public class UDF implements OFValueType<UDF> {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VFI.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VFI.java
@@ -1,10 +1,10 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
+
+import io.netty.buffer.ByteBuf;
 
 /** Represents a two byte virtual forwarding instance.
 *

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VRF.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VRF.java
@@ -2,10 +2,10 @@ package org.projectfloodlight.openflow.types;
 
 import javax.annotation.concurrent.Immutable;
 
-import io.netty.buffer.ByteBuf;
-
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedInts;
+
+import io.netty.buffer.ByteBuf;
 
 @Immutable
 public class VRF implements OFValueType<VRF> {

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VlanPcp.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VlanPcp.java
@@ -1,10 +1,11 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.UnsignedBytes;
+
+import io.netty.buffer.ByteBuf;
 
 public class VlanPcp implements OFValueType<VlanPcp> {
 

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VlanVid.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/types/VlanVid.java
@@ -1,13 +1,13 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.ByteBuf;
-
 import java.util.Arrays;
 
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Shorts;
+
+import io.netty.buffer.ByteBuf;
 
 /** Represents an 802.1Q Vlan VID (12 bits).
  *

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/ChannelUtils.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/ChannelUtils.java
@@ -2,7 +2,6 @@ package org.projectfloodlight.openflow.util;
 
 import java.util.List;
 
-import io.netty.buffer.ByteBuf;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 import org.projectfloodlight.openflow.protocol.OFMessageReader;
 import org.projectfloodlight.openflow.protocol.Writeable;
@@ -12,6 +11,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Collection of helper functions for reading and writing into Unpooled

--- a/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/MultiplePktInReasonUtil.java
+++ b/java_gen/pre-written/src/main/java/org/projectfloodlight/openflow/util/MultiplePktInReasonUtil.java
@@ -2,16 +2,16 @@ package org.projectfloodlight.openflow.util;
 
 import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
-
-import org.projectfloodlight.openflow.types.U64;
 import org.projectfloodlight.openflow.protocol.OFBsnPktinFlag;
 import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFVersion;
-import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.protocol.match.Match;
+import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.protocol.ver13.OFBsnPktinFlagSerializerVer13;
 import org.projectfloodlight.openflow.types.OFMetadata;
+import org.projectfloodlight.openflow.types.U64;
+
+import com.google.common.collect.ImmutableSet;
 
 
 public class MultiplePktInReasonUtil {

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/DatapathIdTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/DatapathIdTest.java
@@ -1,14 +1,13 @@
 package org.projectfloodlight.openflow.types;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 
 import org.junit.Test;
-
-import static org.hamcrest.Matchers.is;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class DatapathIdTest {
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/HashValueUtilsTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/HashValueUtilsTest.java
@@ -1,7 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPv4AddressTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPv4AddressTest.java
@@ -1,14 +1,13 @@
 package org.projectfloodlight.openflow.types;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import io.netty.buffer.Unpooled;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -20,6 +19,8 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
+
+import io.netty.buffer.Unpooled;
 
 public class IPv4AddressTest {
     byte[][] testAddresses = new byte[][] {

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPv6AddressTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/IPv6AddressTest.java
@@ -1,14 +1,13 @@
 package org.projectfloodlight.openflow.types;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import io.netty.buffer.Unpooled;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -20,6 +19,8 @@ import org.junit.Test;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
 import com.google.common.io.BaseEncoding;
+
+import io.netty.buffer.Unpooled;
 
 public class IPv6AddressTest {
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/MacAddressTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/MacAddressTest.java
@@ -1,20 +1,19 @@
 package org.projectfloodlight.openflow.types;
 
-import io.netty.buffer.Unpooled;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 
 import org.junit.Test;
 import org.projectfloodlight.openflow.exceptions.OFParseError;
 
-import static org.hamcrest.Matchers.is;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import io.netty.buffer.Unpooled;
 
 public class MacAddressTest {
     byte[][] testAddresses = new byte[][] {

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFErrorCauseDataTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFErrorCauseDataTest.java
@@ -1,15 +1,16 @@
 package org.projectfloodlight.openflow.types;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
 import org.projectfloodlight.openflow.protocol.OFVersion;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class OFErrorCauseDataTest {
     @Test

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFPortBitMapTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFPortBitMapTest.java
@@ -1,11 +1,12 @@
 package org.projectfloodlight.openflow.types;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
-import junit.framework.TestCase;
 
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 public class OFPortBitMapTest extends TestCase {
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFVlanVidMatchTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/OFVlanVidMatchTest.java
@@ -1,7 +1,7 @@
 package org.projectfloodlight.openflow.types;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/TransportPortTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/TransportPortTest.java
@@ -3,8 +3,8 @@ package org.projectfloodlight.openflow.types;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U128Test.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U128Test.java
@@ -2,14 +2,12 @@ package org.projectfloodlight.openflow.types;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 
 import java.text.MessageFormat;
 
@@ -20,6 +18,9 @@ import org.junit.Test;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class U128Test {
     private Triple[] triples;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U64Test.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/types/U64Test.java
@@ -1,10 +1,10 @@
 package org.projectfloodlight.openflow.types;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/util/HexStringTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/util/HexStringTest.java
@@ -17,9 +17,9 @@
 
 package org.projectfloodlight.openflow.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.util.Random;
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/util/PrimitiveSinkUtilsTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/openflow/util/PrimitiveSinkUtilsTest.java
@@ -2,7 +2,7 @@ package org.projectfloodlight.openflow.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFBundleAddTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFBundleAddTest.java
@@ -1,7 +1,7 @@
 package org.projectfloodlight.protocol;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFOxmListTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFOxmListTest.java
@@ -1,7 +1,7 @@
 package org.projectfloodlight.protocol;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFOxmTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFOxmTest.java
@@ -1,9 +1,9 @@
 package org.projectfloodlight.protocol;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.hamcrest.CoreMatchers;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFPortDescTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFPortDescTest.java
@@ -1,8 +1,8 @@
 package org.projectfloodlight.protocol;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -44,14 +44,14 @@ public class OFPortDescTest {
 
         // Partially disabled
         desc = factory.buildPortDesc()
-                .setConfig(new HashSet<OFPortConfig>(Arrays.asList(OFPortConfig.PORT_DOWN)))
+                .setConfig(new HashSet<>(Arrays.asList(OFPortConfig.PORT_DOWN)))
                 .build();
         assertThat(desc.isEnabled(), is(false));
 
         // Fully disabled
         desc = factory.buildPortDesc()
-                .setConfig(new HashSet<OFPortConfig>(Arrays.asList(OFPortConfig.PORT_DOWN)))
-                .setState(new HashSet<OFPortState>(Arrays.asList(OFPortState.LINK_DOWN)))
+                .setConfig(new HashSet<>(Arrays.asList(OFPortConfig.PORT_DOWN)))
+                .setState(new HashSet<>(Arrays.asList(OFPortState.LINK_DOWN)))
                 .build();
         assertThat(desc.isEnabled(), is(false));
     }

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/MatchFieldIterationBase.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/MatchFieldIterationBase.java
@@ -1,7 +1,7 @@
 package org.projectfloodlight.protocol.match;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Iterator;

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/OFMatchPrerequisitesTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/OFMatchPrerequisitesTest.java
@@ -2,7 +2,7 @@ package org.projectfloodlight.protocol.match;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.projectfloodlight.openflow.protocol.match.MatchField.ETH_TYPE;
 import static org.projectfloodlight.openflow.protocol.match.MatchField.IPV4_SRC;
 

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/PrimitiveNormalizationTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/match/PrimitiveNormalizationTest.java
@@ -2,7 +2,7 @@ package org.projectfloodlight.protocol.match;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFFactories;


### PR DESCRIPTION
This PR  updates openflowj to require java 8; this seems like a reasonable minimum version these days given that Guava etc. have required it for a long time. This enables us to upgrade our dependencies and bring them in line with recent best practices (in particular, consume a Guava security fix).

We also bump the netty IO library to `4.1.50-Final`.

To signal the transition to Java-8 only, we have also bumped the artifact version of openflowJ itself to `3.6.x`; such that anyone consuming patch releases from `3.5.x` isn't caught by the Java 8 requirement by surprise.

