### PR TITLE
ctestgen fixes to avoid creating test messages > 64kB

### DIFF
--- a/c_gen/c_test_gen.py
+++ b/c_gen/c_test_gen.py
@@ -218,7 +218,7 @@ of_test_str_check(uint8_t *buf, int value, int len)
  * to call populate with a max parameter for length
  */
 int octets_pop_style = -1;
-#define OCTETS_MAX_VALUE (128) /* 16K was too big */
+#define OCTETS_MAX_VALUE (64) /* 16K was too big */
 #define OCTETS_MULTIPLIER 6367 /* A prime */
 
 int
@@ -743,13 +743,12 @@ def setup_instance(out, cls, subcls, instance, v_name, version):
     TEST_ASSERT(list->length == cur_len);
 """
     out.write("""
-    /* Append two instances of type %s */
+    /* Append an instance of type %s */
 """ % subcls)
-    for i in range(2):
-        out.write(setup_template %
-                  dict(inst=instance, subcls=subcls, v_name=v_name,
-                       base_type=base_type, cls=cls,
-                       version=version))
+    out.write(setup_template %
+              dict(inst=instance, subcls=subcls, v_name=v_name,
+                   base_type=base_type, cls=cls,
+                   version=version))
 
 def check_instance(out, cls, subcls, instance, v_name, version, last):
     check_template = """
@@ -758,15 +757,7 @@ def check_instance(out, cls, subcls, instance, v_name, version, last):
         %(inst)s, value);
     TEST_ASSERT(value != 0);
 """
-    out.write("\n    /* Check two instances of type %s */" % instance)
-
-    out.write(check_template %
-              dict(elt_name=loxi_utils.enum_name(subcls),
-                   inst=instance, subcls=subcls,
-                   v_name=loxi_utils.version_to_name(version)))
-    out.write("""\
-    TEST_OK(%(cls)s_next(list, &elt));
-""" % dict(cls=cls))
+    out.write("\n    /* Check an instance of type %s */" % instance)
 
     out.write(check_template %
               dict(elt_name=loxi_utils.enum_name(subcls),
@@ -1169,12 +1160,12 @@ int
     v_name = loxi_utils.version_to_name(version)
 
     if not type_maps.class_is_virtual(base_type):
-        entry_count = 2
+        entry_count = 1
         out.write("    /* No subclasses for %s */\n"% base_type)
         out.write("    %s_t *elt_p;\n" % base_type)
         out.write("\n    elt_p = &elt;\n")
     else:
-        entry_count = 2 * len(sub_classes) # Two of each type appended
+        entry_count = len(sub_classes)
         out.write("    /* Declare pointers for each subclass */\n")
         for instance, subcls in sub_classes:
             out.write("    %s_t *%s;\n" % (subcls, instance))

--- a/lang_c.py
+++ b/lang_c.py
@@ -94,11 +94,13 @@ targets = {
     'locitest/inc/locitest/test_common.h': c_test_gen.gen_common_test_header,
     'locitest/src/of_dup.c': c_test_gen.dup_c_gen,
     'locitest/src/test_common.c': c_test_gen.gen_common_test,
+    'locitest/src/test_scalar_setcheck.c': c_test_gen.gen_scalar_set_check,
+    'locitest/src/test_unified_setcheck.c': c_test_gen.gen_unified_set_check,
     'locitest/src/test_list.c': c_test_gen.gen_list_test,
     'locitest/src/test_match.c': c_test_gen.gen_match_test,
     'locitest/src/test_msg.c': c_test_gen.gen_msg_test,
-    'locitest/src/test_scalar_acc.c': c_test_gen.gen_message_scalar_test,
-    'locitest/src/test_uni_acc.c': c_test_gen.gen_unified_accessor_tests,
+    'locitest/src/test_scalar_accessor.c': c_test_gen.gen_message_scalar_test,
+    'locitest/src/test_unified_accessor.c': c_test_gen.gen_unified_accessor_tests,
     'locitest/src/test_data.c': c_test_gen.gen_datafiles_tests,
 
     # Static locitest code


### PR DESCRIPTION
Reviewer: @archerhungbsn 
CC: @3mp4y5 

When more TLVs are added, locitest fails with memory issues ("test of_flow_stats_reply_OF_VERSION_1_3:memory clobbered before allocated block"), because the test messages are greater than 64kB in length.

Also, since the autogenerated files are long, gcc reports “variable tracking size limit exceeded with -fvar-tracking-assignments”.  This results in gcc backtraces with incorrect line numbers and makes debugging annoying.

This pull request has two commits: the first to break up the large autogenerated functions and files leading to the "variable tracking size limit exceeded" warnings, and the second to limit of_octets fields to 64B when populating them in the test code and to append only one of each possible subclass instead of two.

Regarding the locitest failure, the of_flow_stats_reply has a list of OF instructions.  One of those OF instructions is the bsn_gentable action, and this instruction takes a list of TLVs.  So increasing the number of TLVs causes this TLV list to get even longer, and ultimately the complete message occupies more than 64kB, overwriting the memory following the OF object's wire buffer.  After the second commit, the test message is reduced to ~5kB.

