### PR TITLE
Generate python2 and python3 versions of connection.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # EPL for the specific language governing permissions and limitations
 # under the EPL.
 
-# Available targets: all, c, python, clean
+# Available targets: all, c, python2, python3, clean
 
 # This Makefile is just for convenience. Users that need to pass additional
 # options to loxigen.py are encouraged to run it directly.
@@ -47,7 +47,7 @@ TEST_DATA = $(shell find test_data -name '*.data')
 OPENFLOWJ_OUTPUT_DIR = ${LOXI_OUTPUT_DIR}/openflowj
 OPENFLOWJ_ECLIPSE_WORKSPACE = openflowj-loxi
 
-all: c python python3 java wireshark
+all: c python2 python3 java wireshark
 
 c: .loxi_ts.c
 
@@ -55,13 +55,13 @@ c: .loxi_ts.c
 	./loxigen.py --install-dir=${LOXI_OUTPUT_DIR} --lang=c --version-list=1.0,1.1,1.2,1.3,1.4
 	touch $@
 
-python: .loxi_ts.python
+python2: .loxi_ts.python2
 
-.loxi_ts.python: ${LOXI_PY_FILES} ${LOXI_TEMPLATE_FILES} ${INPUT_FILES} ${TEST_DATA}
+.loxi_ts.python2: ${LOXI_PY_FILES} ${LOXI_TEMPLATE_FILES} ${INPUT_FILES} ${TEST_DATA}
 	./loxigen.py --install-dir=${LOXI_OUTPUT_DIR} --lang=python
 	touch $@
 
-python-doc: python
+python2-doc: python2
 	rm -rf ${LOXI_OUTPUT_DIR}/pyloxi-doc
 	mkdir -p ${LOXI_OUTPUT_DIR}/pyloxi-doc
 	cp -a py_gen/sphinx ${LOXI_OUTPUT_DIR}/pyloxi-doc/input
@@ -136,19 +136,19 @@ debug:
 	@echo
 	@echo "INPUT_FILES=\"${INPUT_FILES}\""
 
-check-all: check check-c check-py check-py3 check-java
+check-all: check check-c check-py2 check-py3 check-java
 
 check:
 	nosetests3
 
-check-py: python
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/generic_util.py
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/of10.py
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/of11.py
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/of12.py
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/of13.py
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/of14.py
-	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python py_gen/tests/of15.py
+check-py2: python2
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/generic_util.py
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/of10.py
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/of11.py
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/of12.py
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/of13.py
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/of14.py
+	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi:. python2 py_gen/tests/of15.py
 
 check-py3: python3
 	PYTHONPATH=${LOXI_OUTPUT_DIR}/pyloxi3:. python3 py_gen/tests3/generic_util.py
@@ -179,4 +179,4 @@ coverage:
 	coverage run -a ./loxigen.py --lang=wireshark
 	coverage annotate -i --omit tenjin.py,pyparsing.py
 
-.PHONY: all clean debug check pylint c python python3 coverage
+.PHONY: all clean debug check pylint c python2 python3 coverage

--- a/py_gen/codegen.py
+++ b/py_gen/codegen.py
@@ -90,7 +90,7 @@ def codegen(install_dir, pyversion):
     render('__init__.py', template_name='toplevel_init.py')
     render('pp.py')
     render('generic_util.py', pyversion=pyversion)
-    render('connection.py')
+    render('connection.py', pyversion=pyversion)
 
     for version in loxi_globals.OFVersions.all_supported:
         subdir = 'of' + version.version.replace('.', '')

--- a/py_gen/templates/connection.py
+++ b/py_gen/templates/connection.py
@@ -233,7 +233,11 @@ class Connection(Thread):
         assert not self.finished
         self.logger.debug("Stopping connection")
         self.finished = True
+:: if pyversion == 3:
+        os.write(self.wakeup_wr, b"x")
+:: else:
         os.write(self.wakeup_wr, "x")
+:: #endif
         self.join()
         self.sock.close()
         os.close(self.wakeup_rd)


### PR DESCRIPTION
Reviewer: @3mp4y5 
Rename "python" Makefile targets to "python2"
Explicitly invoke "python2" instead of relying on "python" symlink