### PR TITLE
More user-friendly python pretty-printer output

### DIFF
--- a/loxi_utils/loxi_utils.py
+++ b/loxi_utils/loxi_utils.py
@@ -187,6 +187,13 @@ def lookup_ir_wiretype(oftype, version):
     else:
         return oftype
 
+@memoize
+def lookup_ir_enum(oftype, version):
+    """ if oftype is a reference to an enum in ir,
+        return the value-name mapping; otherwise return None """
+    enums = loxi_globals.ir[version].enums
+    return find(lambda e: e.name == oftype, enums)
+
 def oftype_is_list(oftype):
     return (oftype.find("list(") == 0)
 

--- a/py_gen/templates/_pretty_print.py
+++ b/py_gen/templates/_pretty_print.py
@@ -40,32 +40,47 @@
 :: #endfor
 :: first = True
 :: for m in normal_members:
-:: if not first:
+::   if not first:
                 q.text(","); q.breakable()
-:: else:
-:: first = False
-:: #endif
+::   else:
+::     first = False
+::   #endif
                 q.text("${m.name} = ");
-:: if m.name == "xid":
+::   if m.name == "xid":
                 if self.${m.name} != None:
                     q.text("%#x" % self.${m.name})
                 else:
                     q.text('None')
-:: elif m.oftype == 'of_mac_addr_t':
+::   elif m.oftype == 'of_mac_addr_t':
                 q.text(util.pretty_mac(self.${m.name}))
-:: elif m.oftype == 'of_ipv4_t':
+::   elif m.oftype == 'of_ipv4_t':
                 q.text(util.pretty_ipv4(self.${m.name}))
-:: elif m.oftype == 'of_wc_bmap_t' and version in OFVersions.from_strings("1.0", "1.1"):
+::   elif m.oftype == 'of_wc_bmap_t' and version in OFVersions.from_strings("1.0", "1.1"):
                 q.text(util.pretty_wildcards(self.${m.name}))
-:: elif m.oftype == 'of_port_no_t':
+::   elif m.oftype == 'of_port_no_t':
                 q.text(util.pretty_port(self.${m.name}))
-:: elif m.oftype == 'of_ipv6_t':
+::   elif m.oftype == 'of_ipv6_t':
                 q.text(util.pretty_ipv6(self.${m.name}))
-:: elif loxi_utils.lookup_ir_wiretype(m.oftype, version=version).startswith("uint"):
+::   elif loxi_utils.lookup_ir_wiretype(m.oftype, version=version).startswith("uint"):
+::     enum = loxi_utils.lookup_ir_enum(m.oftype, version=version)
+::     if enum:
+::       value_name_map = { entry.value:entry.name for entry in enum.entries }
+::       if 'bitmask' in enum.params and enum.params['bitmask']:
+                value_name_map = ${value_name_map}
+                q.text(util.pretty_flags(self.${m.name}, value_name_map.values()))
+::       else:
+                value_name_map = ${value_name_map}
+                if self.${m.name} in value_name_map:
+                    q.text("%s(%d)" % (value_name_map[self.${m.name}], self.${m.name}))
+                else:
+                    q.text("%#x" % self.${m.name})
+::       #endif
+::     else:
                 q.text("%#x" % self.${m.name})
-:: else:
+::     #endif
+::   else:
                 q.pp(self.${m.name})
-:: #endif
+::   #endif
 :: #endfor
             q.breakable()
         q.text('}')

--- a/test_data/of10/flow_add.data
+++ b/test_data/of10/flow_add.data
@@ -78,7 +78,7 @@ flow_add {
   priority = 0x0,
   buffer_id = 0x0,
   out_port = 0,
-  flags = 0x2,
+  flags = OFPFF_CHECK_OVERLAP,
   actions = [
     output { port = OFPP_FLOOD, max_len = 0x0 },
     nicira_dec_ttl {  },


### PR DESCRIPTION
Reviewer: @3mp4y5 @archerhungbsn @harishraghavendra 
In python pretty_print methods, print both enum names and values for non-bitmask enums, and ORed flag names for bitmask enums

Previous behavior:
```
>>> import loxi.of14 as ofp
>>> import loxi.pp as pp
>>> tlv = ofp.bsn_tlv.packet_field(1)
>>> pp.pp(tlv)
'packet_field { value = 0x1 }'
```

New behavior:
```
>>> import loxi.of14 as ofp
>>> import loxi.pp as pp
>>> tlv = ofp.bsn_tlv.packet_field(1)
>>> pp.pp(tlv)
'packet_field { value = OFP_BSN_PACKET_FIELD_OUTER_VLAN_TAG_1(1) }'
```
