### PR TITLE
Bump netty to latest patch version

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.50.Final</version>
+            <version>4.1.76.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
netty-all.4.1.50.Final has a number of [known security vulnerabilites](https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Anetty&cpe_product=cpe%3A%2F%3Anetty%3Anetty&cpe_version=cpe%3A%2F%3Anetty%3Anetty%3A4.1.50), ranging from medium to high severity in CVSS 3.1. The latest path version, 4.1.76.Final, fixes these.